### PR TITLE
Add http lib to allow easier init

### DIFF
--- a/http.js
+++ b/http.js
@@ -1,0 +1,19 @@
+const http = require( 'http' );
+
+const SERVER_PORT = process.env.PORT || 7777;
+const HEALTHCHECK_PATH = '/cache-healthcheck?';
+
+export default function createServer( requestListener ) {
+	const server = http.createServer( requestListener );
+
+	server.on( 'request', ( req, res ) => {
+		if ( req.url.startsWith( HEALTHCHECK_PATH ) ) {
+			res.statusCode = 200;
+			return res.end( 'OK' );
+		}
+	} );
+
+	server.listen( SERVER_PORT );
+
+	return server;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@automattic/vip-go-node",
+  "version": "0.1.0",
+  "description": "All set for launch.",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Automattic/vip-go-node.git"
+  },
+  "keywords": [
+    "vip",
+    "vip-go"
+  ],
+  "author": "Automattic",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Automattic/vip-go-node/issues"
+  },
+  "homepage": "https://github.com/Automattic/vip-go-node#readme"
+}


### PR DESCRIPTION
Handles the server init and responds to the healthcheck path so applications don't have to worry about the implementation specifics.

Node:

```
const goHttp = require( '@automattic/vip-go-node/http' );
const server = goHttp( ( request, response ) => {
    // handle requests here
} );
```

Express:

```
const goHttp = require( '@automattic/vip-go-node/http' );

const express = require( 'express' );
const app = express();
const server = goHttp.createServer( app );
```

Koa:

```
const Koa = require( 'koa' );
const app = new Koa();
goHttp.createServer( app.callback() )
```

## TODO

- [ ] `nocache` headers for healthcheck
- [ ] Tests
- [ ] Docs