### PR TITLE
Add HTTP server module

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,8 @@
         "expect": false,
         "require": false,
         "module": false,
-        "process": false
+        "process": false,
+        "console": false,
+        "describe": false
     }
 }

--- a/__tests__/server.tests.js
+++ b/__tests__/server.tests.js
@@ -23,6 +23,7 @@ describe( 'Should work with an express application', () => {
 		const expressServer = server( { express: true, requestHandler: expressApp } );
 		request( 'http://localhost:3000' ).get( HEALTHCHECKURL ).then( ( response ) => {
 			expect( response.statusCode ).toBe( 200 );
+			expect( response.text ).toBe( 'ok' );
 			expressServer.close();
 			done();
 		} );
@@ -63,6 +64,7 @@ describe( 'Should work with a custom request handler', () => {
 		const httpServer = server( { requestHandler: requestHandler } );
 		request( 'http://localhost:3000' ).get( HEALTHCHECKURL ).then( ( response ) => {
 			expect( response.statusCode ).toBe( 200 );
+			expect( response.text ).toBe( 'ok' );
 			httpServer.close();
 			done();
 		} );

--- a/__tests__/server.tests.js
+++ b/__tests__/server.tests.js
@@ -1,0 +1,98 @@
+const server = require( '../src/server/' );
+const expressApp = require( 'express' )();
+const request = require( 'supertest' );
+const healthCheckUrl = '/cache-healthcheck?';
+const requestHandler = ( req, res ) => {
+	if ( req.url === '/custom' ) {
+		res.writeHead( 201 );
+		res.end();
+	}
+
+	res.writeHead( 404 );
+	res.end();
+};
+
+describe( 'Should work with an express application', () => {
+	test( 'Should raise an error if express flag is present and no request handler', () => {
+		expect( () => {
+			server( { express: true } );
+		} ).toThrow();
+	} );
+
+	test( 'Should add a /cache-healthcheck? route returning 200 OK', ( done ) => {
+		const expressServer = server( { express: true, requestHandler: expressApp } );
+		request( 'http://localhost:3000' ).get( healthCheckUrl ).then( ( response ) => {
+			expect( response.statusCode ).toBe( 200 );
+			expressServer.close();
+			done();
+		} );
+	} );
+
+	test( 'Should boot up a server on the provided PORT', ( done ) => {
+		const PORT = 8000;
+		const expressServer = server( { express: true, requestHandler: expressApp, PORT } );
+		request( `http://localhost:${ PORT }` ).get( healthCheckUrl ).then( ( response ) => {
+			expect( response.statusCode ).toBe( 200 );
+			expressServer.close();
+			done();
+		} );
+	} );
+
+	test( 'Should keep already defined routes', ( done ) => {
+		expressApp.get( '/down', ( req, res ) => {
+			res.status( 501 ).end();
+		} );
+
+		const expressServer = server( { express: true, requestHandler: expressApp } );
+		request( 'http://localhost:3000' ).get( '/down' ).then( ( response ) => {
+			expect( response.statusCode ).toBe( 501 );
+			expressServer.close();
+			done();
+		} );
+	} );
+} );
+
+describe( 'Should work with a custom request handler', () => {
+	test( 'Should raise an error if no request handler is passed', () => {
+		expect( () => {
+			server();
+		} ).toThrow();
+	} );
+
+	test( 'Should add a /cache-healthcheck? route returning 200 OK', ( done ) => {
+		const httpServer = server( { requestHandler: requestHandler } );
+		request( 'http://localhost:3000' ).get( healthCheckUrl ).then( ( response ) => {
+			expect( response.statusCode ).toBe( 200 );
+			httpServer.close();
+			done();
+		} );
+	} );
+
+	test( 'Should boot up a server on the provided PORT', ( done ) => {
+		const PORT = 8000;
+		const httpServer = server( { requestHandler: requestHandler, PORT } );
+		request( `http://localhost:${ PORT }` ).get( healthCheckUrl ).then( ( response ) => {
+			expect( response.statusCode ).toBe( 200 );
+			httpServer.close();
+			done();
+		} );
+	} );
+
+	test( 'Should match defined routes', ( done ) => {
+		const httpServer = server( { requestHandler: requestHandler } );
+		request( 'http://localhost:3000' ).get( '/custom' ).then( ( response ) => {
+			expect( response.statusCode ).toBe( 201 );
+			httpServer.close();
+			done();
+		} );
+	} );
+
+	test( 'Should return default response if no route is matched', ( done ) => {
+		const httpServer = server( { requestHandler: requestHandler } );
+		request( 'http://localhost:3000' ).get( '/notfound' ).then( ( response ) => {
+			expect( response.statusCode ).toBe( 404 );
+			httpServer.close();
+			done();
+		} );
+	} );
+} );

--- a/__tests__/server.tests.js
+++ b/__tests__/server.tests.js
@@ -1,7 +1,7 @@
 const server = require( '../src/server/' );
 const expressApp = require( 'express' )();
 const request = require( 'supertest' );
-const healthCheckUrl = '/cache-healthcheck?';
+const HEALTHCHECKURL = '/cache-healthcheck?';
 const requestHandler = ( req, res ) => {
 	if ( req.url === '/custom' ) {
 		res.writeHead( 201 );
@@ -21,7 +21,7 @@ describe( 'Should work with an express application', () => {
 
 	test( 'Should add a /cache-healthcheck? route returning 200 OK', ( done ) => {
 		const expressServer = server( { express: true, requestHandler: expressApp } );
-		request( 'http://localhost:3000' ).get( healthCheckUrl ).then( ( response ) => {
+		request( 'http://localhost:3000' ).get( HEALTHCHECKURL ).then( ( response ) => {
 			expect( response.statusCode ).toBe( 200 );
 			expressServer.close();
 			done();
@@ -31,7 +31,7 @@ describe( 'Should work with an express application', () => {
 	test( 'Should boot up a server on the provided PORT', ( done ) => {
 		const PORT = 8000;
 		const expressServer = server( { express: true, requestHandler: expressApp, PORT } );
-		request( `http://localhost:${ PORT }` ).get( healthCheckUrl ).then( ( response ) => {
+		request( `http://localhost:${ PORT }` ).get( HEALTHCHECKURL ).then( ( response ) => {
 			expect( response.statusCode ).toBe( 200 );
 			expressServer.close();
 			done();
@@ -61,7 +61,7 @@ describe( 'Should work with a custom request handler', () => {
 
 	test( 'Should add a /cache-healthcheck? route returning 200 OK', ( done ) => {
 		const httpServer = server( { requestHandler: requestHandler } );
-		request( 'http://localhost:3000' ).get( healthCheckUrl ).then( ( response ) => {
+		request( 'http://localhost:3000' ).get( HEALTHCHECKURL ).then( ( response ) => {
 			expect( response.statusCode ).toBe( 200 );
 			httpServer.close();
 			done();
@@ -71,7 +71,7 @@ describe( 'Should work with a custom request handler', () => {
 	test( 'Should boot up a server on the provided PORT', ( done ) => {
 		const PORT = 8000;
 		const httpServer = server( { requestHandler: requestHandler, PORT } );
-		request( `http://localhost:${ PORT }` ).get( healthCheckUrl ).then( ( response ) => {
+		request( `http://localhost:${ PORT }` ).get( HEALTHCHECKURL ).then( ( response ) => {
 			expect( response.statusCode ).toBe( 200 );
 			httpServer.close();
 			done();

--- a/__tests__/server.tests.js
+++ b/__tests__/server.tests.js
@@ -13,14 +13,8 @@ const requestHandler = ( req, res ) => {
 };
 
 describe( 'Should work with an express application', () => {
-	test( 'Should raise an error if express flag is present and no request handler', () => {
-		expect( () => {
-			server( { express: true } );
-		} ).toThrow();
-	} );
-
 	test( 'Should add a /cache-healthcheck? route returning 200 OK', ( done ) => {
-		const expressServer = server( { express: true, requestHandler: expressApp } );
+		const expressServer = server( expressApp );
 		request( expressServer.app ).get( HEALTHCHECKURL ).then( ( response ) => {
 			expect( response.statusCode ).toBe( 200 );
 			expect( response.text ).toBe( 'ok' );
@@ -33,26 +27,26 @@ describe( 'Should work with an express application', () => {
 			res.status( 501 ).end();
 		} );
 
-		const expressServer = server( { express: true, requestHandler: expressApp } );
+		const expressServer = server( expressApp );
 		request( expressServer.app ).get( '/down' ).then( ( response ) => {
 			expect( response.statusCode ).toBe( 501 );
 			done();
 		} );
 	} );
 
-    test( 'Should boot up a server on the provided PORT', ( done ) => {
-        let expressServerOnPort = server( { requestHandler: expressApp, express: true, PORT: 8000 } );
-        expressServerOnPort.listen();
-        request( 'http://localhost:8000').get(HEALTHCHECKURL).then( (response) => {
-            expect(response.statusCode).toBe(200);
-            expressServerOnPort.close();
-            done();
-        })
-    } );
+	test( 'Should boot up a server on the provided PORT', ( done ) => {
+		const expressServerOnPort = server( expressApp, { PORT: 8000 } );
+		expressServerOnPort.listen();
+		request( 'http://localhost:8000' ).get( HEALTHCHECKURL ).then( ( response ) => {
+			expect( response.statusCode ).toBe( 200 );
+			expressServerOnPort.close();
+			done();
+		} );
+	} );
 } );
 
 describe( 'Should work with a custom request handler', () => {
-	const httpServer = server( { requestHandler: requestHandler } );
+	const httpServer = server( requestHandler );
 
 	test( 'Should raise an error if no request handler is passed', () => {
 		expect( () => {
@@ -83,12 +77,12 @@ describe( 'Should work with a custom request handler', () => {
 	} );
 
 	test( 'Should boot up a server on the provided PORT', ( done ) => {
-        let httpServerOnPort = server( { requestHandler: requestHandler, PORT: 8000 } );
-        httpServerOnPort.listen();
-        request( 'http://localhost:8000').get(HEALTHCHECKURL).then( (response) => {
-            expect(response.statusCode).toBe(200);
-            httpServerOnPort.close();
-            done();
-        })
-    } );
+		const httpServerOnPort = server( requestHandler, { PORT: 8000 } );
+		httpServerOnPort.listen();
+		request( 'http://localhost:8000' ).get( HEALTHCHECKURL ).then( ( response ) => {
+			expect( response.statusCode ).toBe( 200 );
+			httpServerOnPort.close();
+			done();
+		} );
+	} );
 } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,16 @@
       "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
       "dev": true
     },
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
     "acorn": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
@@ -189,6 +199,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
     "array-union": {
@@ -583,6 +599,32 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "body-parser": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "~1.6.15"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        }
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -656,6 +698,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
     "cache-base": {
@@ -918,10 +966,40 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
+    },
     "convert-source-map": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
       "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
       "dev": true
     },
     "copy-descriptor": {
@@ -1109,6 +1187,18 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -1169,6 +1259,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
     "enabled": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
@@ -1176,6 +1272,12 @@
       "requires": {
         "env-variable": "0.0.x"
       }
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
     },
     "env-variable": {
       "version": "0.0.4",
@@ -1214,6 +1316,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.1"
       }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1433,6 +1541,12 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
     "exec-sh": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
@@ -1552,6 +1666,58 @@
         "jest-matcher-utils": "^23.2.0",
         "jest-message-util": "^23.4.0",
         "jest-regex-util": "^23.3.0"
+      }
+    },
+    "express": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.3",
+        "qs": "6.5.1",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "dev": true
+        }
       }
     },
     "extend": {
@@ -1764,6 +1930,21 @@
         }
       }
     },
+    "finalhandler": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
+      }
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -1823,6 +2004,18 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
+      "dev": true
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -1831,6 +2024,12 @@
       "requires": {
         "map-cache": "^0.2.2"
       }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2603,6 +2802,18 @@
         "whatwg-encoding": "^1.0.1"
       }
     },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -2691,6 +2902,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -3746,6 +3963,12 @@
       "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
       "dev": true
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -3761,6 +3984,12 @@
       "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
       "dev": true
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
     "merge-stream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
@@ -3769,6 +3998,12 @@
       "requires": {
         "readable-stream": "^2.0.1"
       }
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
     },
     "micromatch": {
       "version": "2.3.11",
@@ -3836,6 +4071,12 @@
           }
         }
       }
+    },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.35.0",
@@ -3953,6 +4194,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
     "nice-try": {
@@ -4099,6 +4346,15 @@
         "isobject": "^3.0.1"
       }
     },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4234,6 +4490,12 @@
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
     },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+      "dev": true
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -4268,6 +4530,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
     "path-type": {
@@ -4392,6 +4660,16 @@
         "sisteransi": "^0.1.1"
       }
     },
+    "proxy-addr": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+      "dev": true,
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.8.0"
+      }
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -4437,6 +4715,50 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+          "dev": true,
+          "requires": {
+            "depd": "1.1.1",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.3",
+            "statuses": ">= 1.3.1 < 2"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
           "dev": true
         }
       }
@@ -4844,6 +5166,39 @@
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
+      }
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.2"
+      }
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -4872,6 +5227,12 @@
           }
         }
       }
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -5168,6 +5529,12 @@
         }
       }
     },
+    "statuses": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+      "dev": true
+    },
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
@@ -5249,6 +5616,45 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
+    },
+    "superagent": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
+      "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.1.1",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.0.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "supertest": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.1.0.tgz",
+      "integrity": "sha512-O44AMnmJqx294uJQjfUmEyYOg7d9mylNFsMw/Wkz4evKd1njyPrtCN+U6ZIC7sKtfEVQhfTqFFijlXx8KP/Czw==",
+      "dev": true,
+      "requires": {
+        "methods": "~1.1.2",
+        "superagent": "3.8.2"
+      }
     },
     "supports-color": {
       "version": "5.4.0",
@@ -5491,6 +5897,16 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.18"
+      }
+    },
     "uglify-js": {
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
@@ -5559,6 +5975,12 @@
           }
         }
       }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -5636,6 +6058,12 @@
         "object.getownpropertydescriptors": "^2.0.3"
       }
     },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -5651,6 +6079,12 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "eslint": "^5.2.0",
     "eslint-config-wpcalypso": "^4.0.0",
     "eslint-plugin-wpcalypso": "^4.0.1",
-    "jest": "^23.4.2"
+    "express": "^4.16.3",
+    "jest": "^23.4.2",
+    "supertest": "^3.1.0"
   },
   "dependencies": {
     "winston": "^3.0.0"

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -1,0 +1,39 @@
+# VIP GO HTTP server usage
+## Initialization
+In order to use a VIP Go HTTP server, you need to initialize it with a request handler. The request handler contains the rooting of your server and is used handle requests on your server
+
+The HTTP server supports an `express` app or a `custom` handler. A custom handler is a function taking two arguments (req and res), executed against any request, and should respond to the client's request.
+
+The usage with a custom handler is as follows:
+
+``` js
+const { server } = require('vip-go-node');
+const myRequestHandler = ( req, res ) => {
+    if ( req.url === "/admin/" ) {
+        res.writeHead( 403 );
+        res.end();
+    }
+
+    res.send( 'Hello from the server' );
+};
+
+const myServer = server( { requestHandler: myRequestHandler } );
+```
+To use it with an `express` app, make sure to pass the express application as a request handler and activate the `express` flag as follows:
+``` js
+const { server } = require('vip-go-node');
+const app = require('express')();
+
+const myServer = server( { requestHandler: app, express: true } );
+```
+The `server` module boots the server on the designed PORT and returns the created server. To test it, head to `http://localhost:3000/cache-healthcheck?`. You should receive a `200 OK` HTTP response code if everything is working. This route is **added by default** to all servers created by the module.
+
+## Configuration
+By default, the server will start on port `3000`. If you want to change the port, please include a PORT in the initialization:
+``` js
+const myServer = server( { requestHandler: myRequestHandler, PORT: 8000 } );
+```
+The module will also log to the `console` by default. If you want to include your own logger, please use:
+``` js
+const myServer = server( { requestHandler: myRequestHandler, logger: myLogger } );
+```

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -1,8 +1,8 @@
 # VIP GO HTTP server usage
 ## Initialization
-In order to use a VIP Go HTTP server, you need to initialize it with a request handler. The request handler contains the rooting of your server and is used handle requests on your server
+In order to use a VIP Go HTTP server, you need to initialize it with a request handler. The request handler contains the rooting of your server and is used to handle requests on your server
 
-The HTTP server supports an `express` app or a `custom` handler. A custom handler is a function taking two arguments (req and res), executed against any request, and should respond to the client's request.
+The HTTP server supports an `express` app or a `custom` handler. A custom handler is a function taking two arguments (req and res), executed against every request, and sends a reponse to the client.
 
 The usage with a custom handler is as follows:
 
@@ -17,23 +17,52 @@ const myRequestHandler = ( req, res ) => {
     res.send( 'Hello from the server' );
 };
 
-const myServer = server( { requestHandler: myRequestHandler } );
+const myServer = server( myRequestHandler );
+
+myServer.listen()
 ```
-To use it with an `express` app, make sure to pass the express application as a request handler and activate the `express` flag as follows:
+
+To use it with an `express` app, make sure to pass the express application as a request handler:
 ``` js
 const { server } = require('vip-go-node');
 const app = require('express')();
 
-const myServer = server( { requestHandler: app, express: true } );
+const myServer = server( app );
+
+myServer.listen()
 ```
-The `server` module boots the server on the designed PORT and returns the created server. To test it, head to `http://localhost:3000/cache-healthcheck?`. You should receive a `200 OK` HTTP response code if everything is working. This route is **added by default** to all servers created by the module.
+
+The `.listen()` method takes a callback function as an argument and it's executed after the server is booted up. It can be used as follow:
+
+``` js
+const myServer = server( app );
+
+myServer.listen( () => {
+    console.log('Server ready!')
+} )
+```
+
+The object has a `.close()` too and can be used to stop the server without killing the process.
+
+The app (or request handler) and the server itself are accessible using `.app` and `.server`. Here is a recap of what you can access from the returned object:
+```
+const myServer = server( app );
+
+myServer
+   - .app // The application or request handler passed in the initialization
+   - .server // The server started if any (null otherwise)
+   - .listen( () => {} ) // Starts the server on the designed PORT, can take a callback
+   - .close() // Closes the started server
+```
 
 ## Configuration
-By default, the server will start on port `3000`. If you want to change the port, please include a PORT in the initialization:
+If you have an environment variable called `PORT`, your server will start on this port, otherwise it will default to `3000`. If you want to force a `PORT`, please include it in the initialization as follows:
 ``` js
-const myServer = server( { requestHandler: myRequestHandler, PORT: 8000 } );
+const myServer = server( app, { PORT: 8000 } );
 ```
+To test it, head to `http://localhost:8000/cache-healthcheck?`. You should receive a `200 OK` HTTP response code and an `ok` message if everything is working. This route is **added by default** to all servers created by the module.
+
 The module will also log to the `console` by default. If you want to include your own logger, please use:
 ``` js
-const myServer = server( { requestHandler: myRequestHandler, logger: myLogger } );
+const myServer = server( app, { logger: myLogger } );
 ```

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -1,5 +1,7 @@
-# VIP GO HTTP server usage
+# VIP Go HTTP Server
+
 ## Initialization
+
 In order to use a VIP Go HTTP server, you need to initialize it with a request handler. The request handler contains the rooting of your server and is used to handle requests on your server
 
 The HTTP server supports an `express` app or a `custom` handler. A custom handler is a function taking two arguments (req and res), executed against every request, and sends a reponse to the client.
@@ -7,14 +9,14 @@ The HTTP server supports an `express` app or a `custom` handler. A custom handle
 The usage with a custom handler is as follows:
 
 ``` js
-const { server } = require('vip-go-node');
+const { server } = require( '@automattic/vip-go' );
 const myRequestHandler = ( req, res ) => {
     if ( req.url === "/admin/" ) {
         res.writeHead( 403 );
         res.end();
     }
 
-    res.send( 'Hello from the server' );
+    res.end( 'Hello from the server' );
 };
 
 const myServer = server( myRequestHandler );
@@ -24,8 +26,11 @@ myServer.listen()
 
 To use it with an `express` app, make sure to pass the express application as a request handler:
 ``` js
-const { server } = require('vip-go-node');
+const { server } = require( '@automattic/vip-go' );
+
 const app = require('express')();
+
+app.get( '/', ( req, res ) => res.send( 'Hello World!' ) );
 
 const myServer = server( app );
 
@@ -56,13 +61,17 @@ myServer
 ```
 
 ## Configuration
-If you have an environment variable called `PORT`, your server will start on this port, otherwise it will default to `3000`. If you want to force a `PORT`, please include it in the initialization as follows:
+
+On VIP Go servers, we use an environment variable called `PORT` to start up the server, which is the default that must be used. If not defined, the port defaults to `3000`. If you want to force a `PORT`, please include it in the initialization as follows:
+
 ``` js
-const myServer = server( app, { PORT: 8000 } );
+const myServer = server( app, { PORT: process.env.PORT || 8000 } );
 ```
+
 To test it, head to `http://localhost:8000/cache-healthcheck?`. You should receive a `200 OK` HTTP response code and an `ok` message if everything is working. This route is **added by default** to all servers created by the module.
 
 The module will also log to the `console` by default. If you want to include your own logger, please use:
+
 ``` js
 const myServer = server( app, { logger: myLogger } );
 ```

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,11 +1,11 @@
 const { createServer } = require( 'http' );
-const healthCheckUrl = '/cache-healthcheck?';
+const HEALTHCHECKURL = '/cache-healthcheck?';
 
 module.exports = ( { PORT = 3000, requestHandler, express = false, logger = console } ) => {
 	if ( requestHandler && express ) {
 		logger.info( 'Creating an Express server...' );
-		requestHandler.get( healthCheckUrl, ( req, res ) => {
 			res.status( 200 ).end();
+		requestHandler.get( HEALTHCHECKURL, ( req, res ) => {
 		} );
 
 		logger.info( `Starting server on port ${ PORT }...` );
@@ -15,7 +15,7 @@ module.exports = ( { PORT = 3000, requestHandler, express = false, logger = cons
 	if ( requestHandler ) {
 		logger.info( 'Creating an HTTP server...' );
 		const server = createServer( ( req, res ) => {
-			if ( req.url === healthCheckUrl ) {
+			if ( req.url === HEALTHCHECKURL ) {
 				res.writeHead( 200 );
 				res.end();
 			}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -31,7 +31,7 @@ module.exports = ( app, { PORT, logger = console } = {} ) => {
 			res.status( 200 ).end( 'ok' );
 		} );
 
-		server = app;
+		server = createServer( app );
 	} else {
 		// Custom request handler
 		logger.info( 'Creating an HTTP server...' );

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,0 +1,31 @@
+const { createServer } = require( 'http' );
+const healthCheckUrl = '/cache-healthcheck?';
+
+module.exports = ( { PORT = 3000, requestHandler, express = false, logger = console } ) => {
+	if ( requestHandler && express ) {
+		logger.info( 'Creating an Express server...' );
+		requestHandler.get( healthCheckUrl, ( req, res ) => {
+			res.status( 200 ).end();
+		} );
+
+		logger.info( `Starting server on port ${ PORT }...` );
+		return requestHandler.listen( PORT );
+	}
+
+	if ( requestHandler ) {
+		logger.info( 'Creating an HTTP server...' );
+		const server = createServer( ( req, res ) => {
+			if ( req.url === healthCheckUrl ) {
+				res.writeHead( 200 );
+				res.end();
+			}
+
+			return requestHandler( req, res );
+		} );
+
+		logger.info( `Starting server on port ${ PORT }...` );
+		return server.listen( PORT );
+	}
+
+	throw Error( 'Please include a requestHandler and the appropriate flag' );
+};

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -24,27 +24,16 @@ module.exports = ( app, { PORT, logger = console } = {} ) => {
 
 	let server = null;
 
-	if ( app.route ) {
-		// Express app
-		logger.info( 'Creating an Express server...' );
-		app.get( HEALTHCHECKURL, ( req, res ) => {
-			res.status( 200 ).end( 'ok' );
-		} );
+	logger.info( 'Creating an HTTP server...' );
 
-		server = createServer( app );
-	} else {
-		// Custom request handler
-		logger.info( 'Creating an HTTP server...' );
+	server = createServer( ( req, res ) => {
+		if ( req.url === HEALTHCHECKURL ) {
+			res.writeHead( 200 );
+			res.end( 'ok' );
+		}
 
-		server = createServer( ( req, res ) => {
-			if ( req.url === HEALTHCHECKURL ) {
-				res.writeHead( 200 );
-				res.end( 'ok' );
-			}
-
-			return app( req, res );
-		} );
-	}
+		return app( req, res );
+	} );
 
 	return wrapApplication( server, { PORT: PORT || process.env.PORT || 3000, logger } );
 };

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -4,8 +4,8 @@ const HEALTHCHECKURL = '/cache-healthcheck?';
 module.exports = ( { PORT = 3000, requestHandler, express = false, logger = console } ) => {
 	if ( requestHandler && express ) {
 		logger.info( 'Creating an Express server...' );
-			res.status( 200 ).end();
 		requestHandler.get( HEALTHCHECKURL, ( req, res ) => {
+			res.status( 200 ).end( 'ok' );
 		} );
 
 		logger.info( `Starting server on port ${ PORT }...` );
@@ -17,7 +17,7 @@ module.exports = ( { PORT = 3000, requestHandler, express = false, logger = cons
 		const server = createServer( ( req, res ) => {
 			if ( req.url === HEALTHCHECKURL ) {
 				res.writeHead( 200 );
-				res.end();
+				res.end( 'ok' );
 			}
 
 			return requestHandler( req, res );

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -19,7 +19,7 @@ const wrapApplication = ( application, { PORT, logger } ) => {
 
 module.exports = ( app, { PORT, logger = console } = {} ) => {
 	if ( ! app ) {
-		throw Error( 'Please include a requestHandler and the appropriate flag' );
+		throw Error( 'Please include a requestHandler' );
 	}
 
 	let server = null;


### PR DESCRIPTION
This is the first implementation of the HTTP module. It currently supports `express` and a `custom` request handler.

## Todo
- [x] `custom` handler support
- [x] `express` support
- [x] Adds a healthcheck route
- [x] Custom logger
- [x] Documentation (in progress)

Fix #4 