### PR TITLE
Update Logger API to match other module

### DIFF
--- a/__tests__/logger.tests.js
+++ b/__tests__/logger.tests.js
@@ -13,7 +13,7 @@ describe( 'Logger should fail if some parameters are not initialized', () => {
 describe( 'Logger should format messages and log to the provided transport', () => {
 	test( 'Should log a simple error message', ( done ) => {
 		const transport = new winston.transports.Console();
-		const log = goLogger( { namespace: 'go:application:test', transport } );
+		const log = goLogger( 'go:application:test', { transport } );
 
 		log.info( 'A simple log' );
 
@@ -27,7 +27,7 @@ describe( 'Logger should format messages and log to the provided transport', () 
 
 	test( 'Should format an error message', ( done ) => {
 		const transport = new winston.transports.Console();
-		const log = goLogger( { namespace: 'go:application:test', transport } );
+		const log = goLogger( 'go:application:test', { transport } );
 
 		log.info( 'Should format %s message', 'this' );
 
@@ -44,7 +44,7 @@ describe( 'Logger should format messages and log to the provided transport', () 
 describe( 'Logger should add necessary labels and handle custom ones', () => {
 	test( 'Should add custom labels to the output', ( done ) => {
 		const transport = new winston.transports.Console();
-		const log = goLogger( { namespace: 'go:application:test', transport } );
+		const log = goLogger( 'go:application:test', { transport } );
 
 		log.error( 'Should add my custom label', { customLabel: 'custom value' } );
 
@@ -56,7 +56,7 @@ describe( 'Logger should add necessary labels and handle custom ones', () => {
 
 	test( 'Should format and add new labels to the output', ( done ) => {
 		const transport = new winston.transports.Console();
-		const log = goLogger( { namespace: 'go:application:test', transport } );
+		const log = goLogger( 'go:application:test', { transport } );
 
 		log.error( 'Should format %s, and add my custom label', 'this',
 			{ customLabel: 'custom value' }
@@ -73,7 +73,7 @@ describe( 'Logger should add necessary labels and handle custom ones', () => {
 
 	test( 'Should include all necessary labels', ( done ) => {
 		const transport = new winston.transports.Console();
-		const log = goLogger( { namespace: 'go:application:test', transport } );
+		const log = goLogger( 'go:application:test', { transport } );
 
 		log.error( 'Should have some necessary labels' );
 

--- a/__tests__/logger.tests.js
+++ b/__tests__/logger.tests.js
@@ -2,81 +2,88 @@ const goLogger = require( '../src/logger/' );
 const winston = require( 'winston' );
 const symbolForMessage = Symbol.for( 'message' );
 
-test( 'Should fail if not initialized with a namespace', () => {
-	expect( () => {
-		goLogger.debug( 'This should fail' );
-	} ).toThrow();
-} );
-
-test( 'Should log a simple error message', ( done ) => {
-	const transport = new winston.transports.Console();
-	const log = goLogger( { namespace: 'go:application:test', transport } );
-
-	log.info( 'A simple log' );
-
-	transport.on( 'logged', function( logObject ) {
-		const isIncluded = logObject[ symbolForMessage ].includes( 'A simple log' );
-
-		expect( isIncluded ).toBe( true );
-		done();
+describe( 'Logger should fail if some parameters are not initialized', () => {
+	test( 'Should fail if not initialized with a namespace', () => {
+		expect( () => {
+			goLogger.debug( 'This should fail as namespace is not provided' );
+		} ).toThrow();
 	} );
 } );
 
-test( 'Should format an error message', ( done ) => {
-	const transport = new winston.transports.Console();
-	const log = goLogger( { namespace: 'go:application:test', transport } );
+describe( 'Logger should format messages and log to the provided transport', () => {
+	test( 'Should log a simple error message', ( done ) => {
+		const transport = new winston.transports.Console();
+		const log = goLogger( { namespace: 'go:application:test', transport } );
 
-	log.info( 'Should format %s message', 'this' );
+		log.info( 'A simple log' );
 
-	transport.on( 'logged', function( logObject ) {
-		const isIncluded = logObject[ symbolForMessage ].includes( 'Should format this message' );
+		transport.on( 'logged', function( logObject ) {
+			const isIncluded = logObject[ symbolForMessage ].includes( 'A simple log' );
 
-		expect( isIncluded ).toBe( true );
-		done();
+			expect( isIncluded ).toBe( true );
+			done();
+		} );
+	} );
+
+	test( 'Should format an error message', ( done ) => {
+		const transport = new winston.transports.Console();
+		const log = goLogger( { namespace: 'go:application:test', transport } );
+
+		log.info( 'Should format %s message', 'this' );
+
+		transport.on( 'logged', function( logObject ) {
+			const isIncluded = logObject[ symbolForMessage ]
+				.includes( 'Should format this message' );
+
+			expect( isIncluded ).toBe( true );
+			done();
+		} );
 	} );
 } );
 
-test( 'Should add custom labels to the output', ( done ) => {
-	const transport = new winston.transports.Console();
-	const log = goLogger( { namespace: 'go:application:test', transport } );
+describe( 'Logger should add necessary labels and handle custom ones', () => {
+	test( 'Should add custom labels to the output', ( done ) => {
+		const transport = new winston.transports.Console();
+		const log = goLogger( { namespace: 'go:application:test', transport } );
 
-	log.error( 'Should add my custom label', { customLabel: 'custom value' } );
+		log.error( 'Should add my custom label', { customLabel: 'custom value' } );
 
-	transport.on( 'logged', function( logObject ) {
-		expect( logObject ).toHaveProperty( 'customLabel', 'custom value' );
-		done();
+		transport.on( 'logged', function( logObject ) {
+			expect( logObject ).toHaveProperty( 'customLabel', 'custom value' );
+			done();
+		} );
 	} );
-} );
 
-test( 'Should format and add new labels to the output', ( done ) => {
-	const transport = new winston.transports.Console();
-	const log = goLogger( { namespace: 'go:application:test', transport } );
+	test( 'Should format and add new labels to the output', ( done ) => {
+		const transport = new winston.transports.Console();
+		const log = goLogger( { namespace: 'go:application:test', transport } );
 
-	log.error( 'Should format %s, and add my custom label', 'this',
-		{ customLabel: 'custom value' }
-	);
+		log.error( 'Should format %s, and add my custom label', 'this',
+			{ customLabel: 'custom value' }
+		);
 
-	transport.on( 'logged', function( logObject ) {
-		const isIncluded = logObject[ symbolForMessage ].includes( 'Should format this' );
+		transport.on( 'logged', function( logObject ) {
+			const isIncluded = logObject[ symbolForMessage ].includes( 'Should format this' );
 
-		expect( isIncluded ).toBe( true );
-		expect( logObject ).toHaveProperty( 'customLabel', 'custom value' );
-		done();
+			expect( isIncluded ).toBe( true );
+			expect( logObject ).toHaveProperty( 'customLabel', 'custom value' );
+			done();
+		} );
 	} );
-} );
 
-test( 'Should include all necessary labels', ( done ) => {
-	const transport = new winston.transports.Console();
-	const log = goLogger( { namespace: 'go:application:test', transport } );
+	test( 'Should include all necessary labels', ( done ) => {
+		const transport = new winston.transports.Console();
+		const log = goLogger( { namespace: 'go:application:test', transport } );
 
-	log.error( 'Should have some necessary labels' );
+		log.error( 'Should have some necessary labels' );
 
-	transport.on( 'logged', function( logObject ) {
-		expect( logObject ).toHaveProperty( 'app', 'go' );
-		expect( logObject ).toHaveProperty( 'app_type', ':application:test' );
-		expect( logObject ).toHaveProperty( 'message_type', 'error' );
-		expect( logObject ).toHaveProperty( 'app_process', 'master' );
-		expect( logObject ).toHaveProperty( 'message', 'Should have some necessary labels' );
-		done();
+		transport.on( 'logged', function( logObject ) {
+			expect( logObject ).toHaveProperty( 'app', 'go' );
+			expect( logObject ).toHaveProperty( 'app_type', ':application:test' );
+			expect( logObject ).toHaveProperty( 'message_type', 'error' );
+			expect( logObject ).toHaveProperty( 'app_process', 'master' );
+			expect( logObject ).toHaveProperty( 'message', 'Should have some necessary labels' );
+			done();
+		} );
 	} );
 } );

--- a/src/logger/README.md
+++ b/src/logger/README.md
@@ -5,7 +5,7 @@ In order to use a VIP Go logger, you need to initialize it with a namespace. The
 To initialize a logger:
 ``` js
 const { logger } = require('vip-go-node');
-const log = logger( { namespace: 'application:application_type' } );
+const log = logger( 'application:application_type' );
 ```
 You can start logging now by simply using:
 ``` js

--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -41,7 +41,7 @@ const prodLoggingFormat = printf( output => {
 	return `${ time } ${ app }${ type } ${ JSON.stringify( output ) }`;
 } );
 
-module.exports = ( { namespace, transport } ) => {
+module.exports = ( namespace, { transport } = { } ) => {
 	if ( ! namespace ) {
 		throw Error( 'Please include a namespace to initialize your logger.' );
 	}


### PR DESCRIPTION
This PR will transform the logger API from:
```
const log = logger( { namespace: 'go:api:test', otherArgs } );
```
To:
```
const log = logger( 'go:api:test', { otherArgs } );
```
This will make the API consistent for all our modules (like the HTTP one here #8) and will make the usage more friendly:
``` js
const log = logger( 'go:api:test' );

log.info( 'Something' );
```

The README is updated as well, as well as adding describe blocks to the tests.