### PR TITLE
Add Circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,17 @@
-#
-# Check https://circleci.com/docs/2.0/language-javascript/ for more details
-#
 version: 2
-jobs:
+workflows:
+  version: 2
   build:
+    jobs:
+      - node-base
+      - node-6
+      - node-8
+      - node-10
+
+jobs:
+  node-base: &build-and-test
     docker:
-      - image: circleci/node:6.11
+      - image: circleci/node:latest
 
     working_directory: ~/repo
 
@@ -19,6 +25,7 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
+      # Build the lib
       - run: npm install
 
       - save_cache:
@@ -26,9 +33,21 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
-      # run lint!
+      # Lint + Test
       - run: npm run lint
-
-      # run tests!
       - run: npm run test
 
+  node-6:
+    <<: *build-and-test
+    docker:
+      - image: circleci/node:6
+
+  node-8:
+    <<: *build-and-test
+    docker:
+      - image: circleci/node:8
+
+  node-10:
+    <<: *build-and-test
+    docker:
+      - image: circleci/node:10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,3 +31,4 @@ jobs:
 
       # run tests!
       - run: npm run test
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:6.11
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run lint!
+      - run: npm run lint
+
+      # run tests!
+      - run: npm run test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "lint": "eslint ./ --fix"
+    "lint": "eslint ./"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Runs lint + test.

Set to Node 6.11 which is the lowest version we have on Go right now.

Fixes #7 