### PR TITLE
Server: fix invalid logger level

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -8,7 +8,7 @@ const wrapApplication = ( application, { PORT, logger } ) => {
 		app,
 		server,
 		listen: ( connected ) => {
-			logger.log( 'Starting server on', PORT );
+			logger.info( 'Starting server on ' + PORT );
 			server = app.listen( PORT, connected );
 		},
 		close: () => {


### PR DESCRIPTION
`logger.log` is not valid. Switch to `logger.info` instead.