### PR TITLE
Fix headers already sent error

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,9 @@
     ],
     "extends": "wpcalypso",
     "globals": {
+        "jest": false,
+        "beforeEach": false,
+        "afterEach": false,
         "test": false,
         "expect": false,
         "require": false,

--- a/__tests__/server.tests.js
+++ b/__tests__/server.tests.js
@@ -8,6 +8,8 @@ const requestHandler = ( req, res ) => {
 		res.end();
 	}
 
+	console.log( 'Not found' )
+
 	res.writeHead( 404 );
 	res.end();
 };
@@ -58,6 +60,19 @@ describe( 'Should work with a custom request handler', () => {
 		request( httpServer.app ).get( HEALTHCHECKURL ).then( ( response ) => {
 			expect( response.statusCode ).toBe( 200 );
 			expect( response.text ).toBe( 'ok' );
+			done();
+		} );
+	} );
+
+	test( 'Should respond to /cache-healthcheck? route and not forward the request', ( done ) => {
+		const consoleSpy = jest.spyOn( console, 'log' );
+
+		request( httpServer.app ).get( HEALTHCHECKURL ).then( ( response ) => {
+			expect( response.statusCode ).toBe( 200 );
+			expect( response.text ).toBe( 'ok' );
+			expect( consoleSpy ).not.toHaveBeenCalled();
+
+			consoleSpy.mockRestore();
 			done();
 		} );
 	} );

--- a/__tests__/server.tests.js
+++ b/__tests__/server.tests.js
@@ -8,7 +8,8 @@ const requestHandler = ( req, res ) => {
 		res.end();
 	}
 
-	console.log( 'Not found' )
+	// eslint-disable-next-line no-console
+	console.log( 'Not found' );
 
 	res.writeHead( 404 );
 	res.end();
@@ -65,6 +66,7 @@ describe( 'Should work with a custom request handler', () => {
 	} );
 
 	test( 'Should respond to /cache-healthcheck? route and not forward the request', ( done ) => {
+		// eslint-disable-next-line no-undef
 		const consoleSpy = jest.spyOn( console, 'log' );
 
 		request( httpServer.app ).get( HEALTHCHECKURL ).then( ( response ) => {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -29,7 +29,7 @@ module.exports = ( app, { PORT, logger = console } = {} ) => {
 	server = createServer( ( req, res ) => {
 		if ( req.url === HEALTHCHECKURL ) {
 			res.writeHead( 200 );
-			res.end( 'ok' );
+			return res.end( 'ok' );
 		}
 
 		return app( req, res );


### PR DESCRIPTION
Fixes #19 

This will return and terminate the request instead of passing it to the next handler