### PR TITLE
Add New Relic support

### DIFF
--- a/__mocks__/newrelic.js
+++ b/__mocks__/newrelic.js
@@ -1,3 +1,3 @@
 module.exports = {
-    value: 'newrelic'
-}
+	value: 'newrelic',
+};

--- a/__mocks__/newrelic.js
+++ b/__mocks__/newrelic.js
@@ -1,0 +1,3 @@
+module.exports = {
+    value: 'newrelic'
+}

--- a/__tests__/newrelic.tests.js
+++ b/__tests__/newrelic.tests.js
@@ -1,42 +1,44 @@
 const newrelic = require( '../src/newrelic/' );
 
-describe( 'Should fail if some environment variables are not present', () => {
-	const OLD_ENV_VARS = process.env;
+describe( 'src/newrelic', () => {
+	describe( 'Should fail if some environment variables are not present', () => {
+		const OLD_ENV_VARS = process.env;
 
-	// eslint-disable-next-line no-undef
-	afterEach( () => {
-		process.env = OLD_ENV_VARS;
+		// eslint-disable-next-line no-undef
+		afterEach( () => {
+			process.env = OLD_ENV_VARS;
+		} );
+
+		test( 'Should fail if NEW_RELIC_NO_CONFIG_FILE is not set', () => {
+			expect( () => {
+				newrelic();
+			} ).toThrowError( /NEW_RELIC_NO_CONFIG_FILE/ );
+		} );
+
+		test( 'Should fail if NEW_RELIC_NO_CONFIG_FILE is set to false', () => {
+			process.env.NEW_RELIC_NO_CONFIG_FILE = false;
+
+			expect( () => {
+				newrelic();
+			} ).toThrowError( /NEW_RELIC_NO_CONFIG_FILE/ );
+		} );
+
+		test( 'Should fail if NEW_RELIC_LICENSE_KEY is not set', () => {
+			process.env.NEW_RELIC_NO_CONFIG_FILE = true;
+
+			expect( () => {
+				newrelic();
+			} ).toThrowError( /NEW_RELIC_LICENSE_KEY/ );
+		} );
 	} );
 
-	test( 'Should fail if NEW_RELIC_NO_CONFIG_FILE is not set', () => {
-		expect( () => {
-			newrelic();
-		} ).toThrowError( /NEW_RELIC_NO_CONFIG_FILE/ );
-	} );
+	describe( 'Should return expected values when all configuration is present', () => {
+		test( 'Should return newrelic module', () => {
+			process.env.NEW_RELIC_NO_CONFIG_FILE = true;
+			process.env.NEW_RELIC_LICENSE_KEY = 'ABC';
+			const returnedValue = newrelic();
 
-	test( 'Should fail if NEW_RELIC_NO_CONFIG_FILE is set to false', () => {
-		process.env.NEW_RELIC_NO_CONFIG_FILE = false;
-
-		expect( () => {
-			newrelic();
-		} ).toThrowError( /NEW_RELIC_NO_CONFIG_FILE/ );
-	} );
-
-	test( 'Should fail if NEW_RELIC_LICENSE_KEY is not set', () => {
-		process.env.NEW_RELIC_NO_CONFIG_FILE = true;
-
-		expect( () => {
-			newrelic();
-		} ).toThrowError( /NEW_RELIC_LICENSE_KEY/ );
-	} );
-} );
-
-describe( 'Should return expected values when all configuration is present', () => {
-	test( 'Should return newrelic module', () => {
-		process.env.NEW_RELIC_NO_CONFIG_FILE = true;
-		process.env.NEW_RELIC_LICENSE_KEY = 'ABC';
-		const returnedValue = newrelic();
-
-		expect( returnedValue.value ).toEqual( 'newrelic' );
+			expect( returnedValue.value ).toEqual( 'newrelic' );
+		} );
 	} );
 } );

--- a/__tests__/newrelic.tests.js
+++ b/__tests__/newrelic.tests.js
@@ -1,0 +1,12 @@
+const newrelic = require( '../src/newrelic/' );
+
+test( 'New Relic module should fail if no license key is given', () => {
+	// eslint-disable-next-line no-undef
+	const spyOnError = jest.spyOn( console, 'error' );
+
+	newrelic();
+
+	expect( spyOnError ).toHaveBeenCalled();
+
+	spyOnError.mockRestore();
+} );

--- a/__tests__/newrelic.tests.js
+++ b/__tests__/newrelic.tests.js
@@ -1,12 +1,42 @@
 const newrelic = require( '../src/newrelic/' );
 
-test( 'New Relic module should fail if no license key is given', () => {
+describe( 'Should fail if some environment variables are not present', () => {
+	const OLD_ENV_VARS = process.env;
+
 	// eslint-disable-next-line no-undef
-	const spyOnError = jest.spyOn( console, 'error' );
+	afterEach( () => {
+		process.env = OLD_ENV_VARS;
+	} );
 
-	newrelic();
+	test( 'Should fail if NEW_RELIC_NO_CONFIG_FILE is not set', () => {
+		expect( () => {
+			newrelic();
+		} ).toThrowError( /NEW_RELIC_NO_CONFIG_FILE/ );
+	} );
 
-	expect( spyOnError ).toHaveBeenCalled();
+	test( 'Should fail if NEW_RELIC_NO_CONFIG_FILE is set to false', () => {
+		process.env.NEW_RELIC_NO_CONFIG_FILE = false;
 
-	spyOnError.mockRestore();
+		expect( () => {
+			newrelic();
+		} ).toThrowError( /NEW_RELIC_NO_CONFIG_FILE/ );
+	} );
+
+	test( 'Should fail if NEW_RELIC_LICENSE_KEY is not set', () => {
+		process.env.NEW_RELIC_NO_CONFIG_FILE = true;
+
+		expect( () => {
+			newrelic();
+		} ).toThrowError( /NEW_RELIC_LICENSE_KEY/ );
+	} );
+} );
+
+describe( 'Should return expected values when all configuration is present', () => {
+	test( 'Should return newrelic module', () => {
+		process.env.NEW_RELIC_NO_CONFIG_FILE = true;
+		process.env.NEW_RELIC_LICENSE_KEY = 'ABC';
+		const returnedValue = newrelic();
+
+		expect( returnedValue.value ).toEqual( 'newrelic' );
+	} );
 } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,11 +34,33 @@
         "glob-to-regexp": "^0.3.0"
       }
     },
+    "@newrelic/koa": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-1.0.5.tgz",
+      "integrity": "sha512-1zTojq9gW2mi0YblGrS86gCyL56+gbCn6o2+1UJJL3pFmBgp8IAMzZ93PkHHtdrbL3BnVMBrD2Q2WR32FbhIAg==",
+      "requires": {
+        "methods": "^1.1.2"
+      }
+    },
+    "@newrelic/native-metrics": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-3.1.0.tgz",
+      "integrity": "sha512-45OhFKiRT5L+hBzAkDkR5UTuHWIUNMjwlMlu65Y8HmyrTPtgUMKoqMmHERRX4aRqb/EEaW3oWYYLOpLnB6fiHg==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.10.0"
+      }
+    },
     "@nodelib/fs.stat": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz",
       "integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A==",
       "dev": true
+    },
+    "@tyriar/fibonacci-heap": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.7.tgz",
+      "integrity": "sha512-DANf9u0VN5oWrRk31B+xCy9mMNx1H9YhWUaTzCzU0uBruj/zg8u9JSw5qpArntvfJxaW/gWGWbQtzpAkYO6VBg=="
     },
     "abab": {
       "version": "2.0.0",
@@ -84,7 +106,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
       "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-      "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -1262,8 +1283,7 @@
     "buffer-from": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
-      "dev": true
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1685,6 +1705,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "configstore": {
       "version": "3.1.2",
@@ -2205,14 +2236,12 @@
     "es6-promise": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
-      "dev": true
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -3668,7 +3697,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -3951,7 +3979,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-      "dev": true,
       "requires": {
         "agent-base": "^4.1.0",
         "debug": "^3.1.0"
@@ -4967,8 +4994,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "0.5.1",
@@ -5306,8 +5332,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
       "version": "2.3.11",
@@ -5466,8 +5491,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -5479,7 +5503,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-      "dev": true,
       "optional": true
     },
     "nanomatch": {
@@ -5520,6 +5543,22 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
+    },
+    "newrelic": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-4.8.0.tgz",
+      "integrity": "sha512-eteq0KPDBoG6lnNhRspf7I+dyWcXkcBZpFjekQ2CZM43XhOg9XM6/gaylzGqfuDqZ4Ld62OhddTrZhG73FLgUQ==",
+      "requires": {
+        "@newrelic/koa": "^1.0.0",
+        "@newrelic/native-metrics": "^3.0.0",
+        "@tyriar/fibonacci-heap": "^2.0.7",
+        "async": "^2.1.4",
+        "concat-stream": "^1.5.0",
+        "https-proxy-agent": "^2.2.1",
+        "json-stringify-safe": "^5.0.0",
+        "readable-stream": "^2.1.4",
+        "semver": "^5.3.0"
+      }
     },
     "nice-try": {
       "version": "1.0.4",
@@ -6981,8 +7020,7 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-      "dev": true
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -7767,6 +7805,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "supertest": "^3.1.0"
   },
   "dependencies": {
+    "newrelic": "^4.8.0",
     "winston": "^3.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 const logger = require( './logger/' );
 const server = require( './server/' );
+const newrelic = require( './newrelic/' );
 
 module.exports = {
 	logger,
 	server,
+    newrelic,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -5,5 +5,5 @@ const newrelic = require( './newrelic/' );
 module.exports = {
 	logger,
 	server,
-    newrelic,
+	newrelic,
 };

--- a/src/newrelic/README.md
+++ b/src/newrelic/README.md
@@ -1,0 +1,18 @@
+# VIP Go New Relic integration
+
+## Initialization
+In order to use the New Relic integration, you need to call it before starting your application (preferably the first line of your main `app.js` or `index.js`). New Relic needs to bootstrap itself before your application in order to work properly.
+
+To initialize the integration:
+``` js
+const { newrelic } = require( '@automattic/vip-go' );
+newrelic();
+```
+
+This will automatically grab information from your environment on VIP Go and bootup New Relic.
+
+By default, this module logs to the console. If you want to pass your own logger, please do as follow:
+``` js
+const { newrelic } = require( '@automattic/vip-go' );
+newrelic( { logger: yourLogger } );
+```

--- a/src/newrelic/index.js
+++ b/src/newrelic/index.js
@@ -1,12 +1,16 @@
 module.exports = ( { logger = console } = {} ) => {
 	const licenseKey = process.env.NEW_RELIC_LICENSE_KEY;
-	const noConfig = process.env.NEW_RELIC_NO_CONFIG_FILE;
-	const isProduction = () => process.env.NODE_ENV === 'production';
+	const noConfig = process.env.NEW_RELIC_NO_CONFIG_FILE === 'true';
 
-	if ( isProduction && noConfig && licenseKey ) {
-		logger.info( 'Importing New Relic library...' );
-		return require( 'newrelic' );
+	if ( ! noConfig ) {
+		throw new Error( `An environment variable is missing 
+			or not set to true: NEW_RELIC_NO_CONFIG_FILE` );
 	}
 
-	logger.error( 'New Relic could not be loaded, environment variables are not present' );
+	if ( ! licenseKey ) {
+		throw new Error( 'An environment variable is missing: NEW_RELIC_LICENSE_KEY' );
+	}
+
+	logger.info( 'Importing New Relic library...' );
+	return require( 'newrelic' );
 };

--- a/src/newrelic/index.js
+++ b/src/newrelic/index.js
@@ -1,0 +1,12 @@
+module.exports = ( { logger = console } = {} ) => {
+	const licenseKey = process.env.NEW_RELIC_LICENSE_KEY;
+	const noConfig = process.env.NEW_RELIC_NO_CONFIG_FILE;
+	const isProduction = () => process.env.NODE_ENV === 'production';
+
+	if ( isProduction && noConfig && licenseKey ) {
+		logger.info( 'Importing New Relic library...' );
+		return require( 'newrelic' );
+	}
+
+	logger.error( 'New Relic could not be loaded, environment variables are not present' );
+};


### PR DESCRIPTION
Fixes #3 

This basically adds some sanity checks before requiring the `newrelic` library. We'll need the following as env variables for each container:

```
NEW_RELIC_APP_NAME  // (optional) The name that shows in New Relic (default in newrelic is My Application)
NEW_RELIC_LICENSE_KEY // (required) License key to use
NEW_RELIC_NO_CONFIG_FILE // (required) Should be true to use env variables instead of config file
```

Is there somewhere where we need to properly set those? I can take care of the implementation. (or we just write it down for now?)

This PR still needs:
- [ ] Implement (or note) env variables to set
- [x] README for New Relic
- [x] Expose it in `index`