### PR TITLE
Add DEBUG logs to local transport

### DIFF
--- a/__tests__/logger.tests.js
+++ b/__tests__/logger.tests.js
@@ -39,7 +39,7 @@ describe( 'Logger should format messages and log to the provided transport', () 
 		const transport = new TestTransport();
 		const log = goLogger( 'go:application:test', { transport } );
 
-		log.info( 'Should format %s message', 'this' );
+		log.debug( 'Should format %s message', 'this' );
 
 		const firstLog = transport.logs[ 0 ];
 

--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -53,6 +53,7 @@ module.exports = ( namespace, { transport } = { } ) => {
 	}
 
 	const consoleLogging = isLocal() ? localLoggingFormat : prodLoggingFormat;
+	const level = isLocal() ? 'debug' : 'info';
 
 	const formatLogEntry = createLogEntry( namespace );
 
@@ -69,6 +70,7 @@ module.exports = ( namespace, { transport } = { } ) => {
 		),
 		// Allow the user to define a transport (used for tests too)
 		transports: [ transport || new transports.Console ],
+		level,
 	} );
 
 	return winstonLogger;


### PR DESCRIPTION
this adds the `DEBUG` logging level to the local transport.

it also changes a test from `.info` to `.debug` in order to test this without adding another test

this fixes #35 