### PR TITLE
Add cluster support to logger

### DIFF
--- a/__tests__/logger.tests.js
+++ b/__tests__/logger.tests.js
@@ -125,3 +125,23 @@ describe( 'Logger should add necessary labels and handle custom ones', () => {
 		expect( firstLog ).toHaveProperty( 'app_worker', 'master' );
 	} );
 } );
+
+describe( 'Logger should work in a cluster environments', () => {
+	it( 'Should add worker info', () => {
+		const mockedCluster = {
+			isWorker: true,
+			worker: {
+				id: 1234,
+			},
+		};
+
+		const transport = new TestTransport();
+		const log = goLogger( 'go:application:test', { transport, cluster: mockedCluster } );
+
+		log.info( 'Logging from worker' );
+
+		const firstLog = transport.logs[ 0 ];
+
+		expect( firstLog ).toHaveProperty( 'app_worker', 'worker_1234' );
+	} );
+} );

--- a/__tests__/logger.tests.js
+++ b/__tests__/logger.tests.js
@@ -77,7 +77,7 @@ describe( 'Logger should format messages and log to the provided transport', () 
 
 			const message = firstLog[ symbolForMessage ];
 			// eslint-disable-next-line max-len
-			expect( message ).toEqual( expect.stringMatching( /^\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} GMT go:app {"message":"my message","level":"info","app":"go","app_type":"app","message_type":"info","app_process":"master"}$/ ) );
+			expect( message ).toEqual( expect.stringMatching( /^\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} GMT go:app {"message":"my message","level":"info","app":"go","app_type":"app","message_type":"info","app_process":"master","app_worker":"master"}$/ ) );
 		} );
 	} );
 } );
@@ -122,5 +122,6 @@ describe( 'Logger should add necessary labels and handle custom ones', () => {
 		expect( firstLog ).toHaveProperty( 'app_type', 'application:test' );
 		expect( firstLog ).toHaveProperty( 'message_type', 'error' );
 		expect( firstLog ).toHaveProperty( 'app_process', 'master' );
+		expect( firstLog ).toHaveProperty( 'app_worker', 'master' );
 	} );
 } );

--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -1,12 +1,12 @@
 const { createLogger, format, transports } = require( 'winston' );
-const cluster = require( 'cluster' );
+const nodeCluster = require( 'cluster' );
 const { combine, timestamp, printf, splat } = format;
 
 const appProcess = process.env.NODEJS_APP_PROCESS || 'master';
 
 const isLocal = () => ! process.env.VIP_GO_APP_ID;
 
-const createLogEntry = namespace => {
+const createLogEntry = ( namespace, cluster ) => {
 	return format( info => {
 		const { level, message } = info;
 
@@ -60,7 +60,7 @@ const prodLoggingFormat = printf( output => {
 	return `${ time } ${ app }:${ type } ${ JSON.stringify( output ) }`;
 } );
 
-module.exports = ( namespace, { transport } = { } ) => {
+module.exports = ( namespace, { transport, cluster } ) => {
 	if ( ! namespace ) {
 		throw Error( 'Please include a namespace to initialize your logger.' );
 	}
@@ -68,7 +68,7 @@ module.exports = ( namespace, { transport } = { } ) => {
 	const consoleLogging = isLocal() ? localLoggingFormat : prodLoggingFormat;
 	const level = isLocal() ? 'debug' : 'info';
 
-	const formatLogEntry = createLogEntry( namespace );
+	const formatLogEntry = createLogEntry( namespace, cluster || nodeCluster );
 
 	const winstonLogger = createLogger( {
 		format: combine(


### PR DESCRIPTION
This adds cluster support to the logger.

To be able to test it, I made it possible to inject the cluster object into the logger. This is not a breaking change but couldn't see another way of testing this.

note: once this merged, I'll make another PR to move all tests inside a `describe( 'src/logger' )` and `describe( 'src/server' )`

fixes #41 