### PR TITLE
Add uncaughtException handler

### DIFF
--- a/src/logger/README.md
+++ b/src/logger/README.md
@@ -8,10 +8,23 @@ To initialize a logger:
 const { logger } = require( '@automattic/vip-go' );
 const log = logger( 'application:application_type' );
 ```
+
 You can start logging now by simply using:
 ``` js
 log.info( 'This is a log from my application' );
 ```
+
+We recommand you add an `uncaughtException` logger with a unique namespace so you can filter exceptions easily afterwards:
+
+``` js
+const { logger } = require( '@automattic/vip-go' );
+const log = logger( 'application:uncaughtException' );
+
+process.on( 'uncaughtException', err => {
+	log.error( `Uncaught exception: ${ err }` );
+} );
+```
+
 ## Logging levels
 This logger is based on `winston`, so expect to find all [logging levels](https://github.com/winstonjs/winston#logging-levels) provided by it. This means: `debug`, `info`, `notice`, `warning`, `error`, `crit`, `alert` and `emerg` can all be used.
 
@@ -21,6 +34,7 @@ log.debug( 'This is a log from my application' );
 log.error( 'This is a log from my application' );
 // etc
 ```
+
 ## Formatting messages
 This logger supports formatting messages by default. You can use it as follows:
 ``` js

--- a/src/logger/README.md
+++ b/src/logger/README.md
@@ -14,11 +14,13 @@ You can start logging now by simply using:
 log.info( 'This is a log from my application' );
 ```
 
+## Uncaught Exceptions
+
 We recommand you add an `uncaughtException` logger with a unique namespace so you can filter exceptions easily afterwards:
 
 ``` js
 const { logger } = require( '@automattic/vip-go' );
-const log = logger( 'application:uncaughtException' );
+const log = logger( 'my-application:uncaughtException' );
 
 process.on( 'uncaughtException', err => {
 	log.error( `Uncaught exception: ${ err }` );

--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -86,5 +86,9 @@ module.exports = ( namespace, { transport, cluster } ) => {
 		level,
 	} );
 
+	process.on( 'uncaughtException', err => {
+		winstonLogger.error( `Uncaught exception: ${ err }` );
+	} );
+
 	return winstonLogger;
 };

--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -60,11 +60,6 @@ const prodLoggingFormat = printf( output => {
 	return `${ time } ${ app }:${ type } ${ JSON.stringify( output ) }`;
 } );
 
-// Add Uncaught exception handler
-process.on( 'uncaughtException', err => {
-	winstonLogger.error( `Uncaught exception: ${ err }` );
-} );
-
 module.exports = ( namespace, { transport, cluster } ) => {
 	if ( ! namespace ) {
 		throw Error( 'Please include a namespace to initialize your logger.' );

--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -60,6 +60,11 @@ const prodLoggingFormat = printf( output => {
 	return `${ time } ${ app }:${ type } ${ JSON.stringify( output ) }`;
 } );
 
+// Add Uncaught exception handler
+process.on( 'uncaughtException', err => {
+	winstonLogger.error( `Uncaught exception: ${ err }` );
+} );
+
 module.exports = ( namespace, { transport, cluster } ) => {
 	if ( ! namespace ) {
 		throw Error( 'Please include a namespace to initialize your logger.' );
@@ -84,10 +89,6 @@ module.exports = ( namespace, { transport, cluster } ) => {
 		// Allow the user to define a transport (used for tests too)
 		transports: [ transport || new transports.Console ],
 		level,
-	} );
-
-	process.on( 'uncaughtException', err => {
-		winstonLogger.error( `Uncaught exception: ${ err }` );
 	} );
 
 	return winstonLogger;


### PR DESCRIPTION
This adds an `uncaughtException` handler that logs the exception as error.

For tests, couldn't find how to do it as it seems there is a regression in `jest` when trying to raise an exception or rejection https://github.com/facebook/jest/issues/5620

Fixes #5 