### PR TITLE
Remove duplicate linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       # Lint + Test
-      - run: npm run lint
       - run: npm run test
 
   node-6:


### PR DESCRIPTION
`npm run test` runs both linting and Jest, so we can call it (on its own) in CircleCI to prevent double linting.