### PR TITLE
Add silent option

### DIFF
--- a/__tests__/logger.tests.js
+++ b/__tests__/logger.tests.js
@@ -146,4 +146,15 @@ describe( 'src/logger', () => {
 			expect( firstLog ).toHaveProperty( 'app_worker', 'worker_1234' );
 		} );
 	} );
+
+	describe( 'Logger should not log if silent flag is true', () => {
+		it( 'Should add worker info', () => {
+			const transport = new TestTransport();
+			const log = goLogger( 'go:application:test', { transport, silent: true } );
+
+			log.error( 'This should not be logged!' );
+
+			expect( transport.logs ).toHaveLength( 0 );
+		} );
+	} );
 } );

--- a/src/logger/index.js
+++ b/src/logger/index.js
@@ -60,7 +60,7 @@ const prodLoggingFormat = printf( output => {
 	return `${ time } ${ app }:${ type } ${ JSON.stringify( output ) }`;
 } );
 
-module.exports = ( namespace, { transport, cluster } ) => {
+module.exports = ( namespace, { transport, cluster, silent = false } ) => {
 	if ( ! namespace ) {
 		throw Error( 'Please include a namespace to initialize your logger.' );
 	}
@@ -84,6 +84,7 @@ module.exports = ( namespace, { transport, cluster } ) => {
 		// Allow the user to define a transport (used for tests too)
 		transports: [ transport || new transports.Console ],
 		level,
+		silent,
 	} );
 
 	return winstonLogger;


### PR DESCRIPTION
This adds a `silent` flag to our logger (handy for tests)

The README is missing a doc on this, but figured out we are missing the `transport` and `cluster` docs too. So I logged it here #84 and will work on it in a later PR