### PR TITLE
Remove New Relic as a peerDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ const { server, logger, newrelic } = require( '@automattic/vip-go' );
 
 Please refer the documentation for each module ([`server`](https://github.com/Automattic/vip-go-node/blob/master/src/server/README.md) | [`logger`](https://github.com/Automattic/vip-go-node/blob/master/src/logger/README.md) | [`newrelic`](https://github.com/Automattic/vip-go-node/blob/master/src/newrelic/README.md)) to learn more about how to use it.
 
-Also remember to install [New Relic](https://docs.newrelic.com/docs/agents/manage-apm-agents/installation/install-agent) if your app requires it.
+New Relic is no longer a peer dependency of this module. Please remember to install [New Relic](https://docs.newrelic.com/docs/agents/manage-apm-agents/installation/install-agent) separately if your app requires it.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ const { server, logger, newrelic } = require( '@automattic/vip-go' );
 
 Please refer the documentation for each module ([`server`](https://github.com/Automattic/vip-go-node/blob/master/src/server/README.md) | [`logger`](https://github.com/Automattic/vip-go-node/blob/master/src/logger/README.md) | [`newrelic`](https://github.com/Automattic/vip-go-node/blob/master/src/newrelic/README.md)) to learn more about how to use it.
 
+Also remember to install [New Relic](https://docs.newrelic.com/docs/agents/manage-apm-agents/installation/install-agent) if your app requires it.
+
 ## Development
 
 ### Using hooks

--- a/package-lock.json
+++ b/package-lock.json
@@ -3918,8 +3918,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3940,14 +3939,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3962,20 +3959,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4092,8 +4086,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4105,7 +4098,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4120,7 +4112,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4128,14 +4119,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4154,7 +4143,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4235,8 +4223,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4248,7 +4235,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4334,8 +4320,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4371,7 +4356,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4391,7 +4375,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4435,14 +4418,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -45,8 +45,5 @@
   },
   "dependencies": {
     "winston": "^3.0.0"
-  },
-  "peerDependencies": {
-    "newrelic": "^4.8.0"
   }
 }

--- a/src/newrelic/README.md
+++ b/src/newrelic/README.md
@@ -1,7 +1,7 @@
 # VIP Go New Relic integration
 
 ## Initialization
-If your app requires New Relic, you can run the following to install the `newrelic` package:
+New Relic is no longer a peer dependency for this module. If your app requires New Relic, you can run the following command to install the `newrelic` package:
 
 ```
 npm install --save newrelic@^4.8.0

--- a/src/newrelic/README.md
+++ b/src/newrelic/README.md
@@ -1,9 +1,7 @@
 # VIP Go New Relic integration
 
 ## Initialization
-New Relic's package (`newrelic`) is a peer dependency of this module. This means, in order to use it, you need to install it manually. This ensures we're not obliging you to use a specific version, but will use whatever version you're using already.
-
-If you don't have the New Relic package installed, you can run the following:
+If your app requires New Relic, you can run the following to install the `newrelic` package:
 
 ```
 npm install --save newrelic@^4.8.0


### PR DESCRIPTION
Fixes issue #101 

Removing New Relic as a peer dependency so projects that don't use or require NR won't prop up unnecessary warnings that can potentially fail builds.