### PR TITLE
Skip newrelic in local and stop throwing when env vars are missing

### DIFF
--- a/__tests__/newrelic.tests.js
+++ b/__tests__/newrelic.tests.js
@@ -39,7 +39,7 @@ describe( 'src/newrelic', () => {
 			const transport = new TestTransport();
 			newrelic( { logger: transport } );
 
-			expect( transport.logs[ 0 ] ).toMatch( 'skipping Newrelic' );
+			expect( transport.logs[ 0 ] ).toMatch( 'skipping New Relic' );
 		} );
 
 		it( 'Should fail if NEW_RELIC_NO_CONFIG_FILE is not set', () => {

--- a/__tests__/newrelic.tests.js
+++ b/__tests__/newrelic.tests.js
@@ -1,4 +1,21 @@
 const newrelic = require( '../src/newrelic/' );
+const Transport = require( 'winston-transport' );
+
+class TestTransport extends Transport {
+	constructor( opts ) {
+		super( opts );
+		this.logs = [];
+		this.errors = [];
+	}
+
+	log( info ) {
+		this.logs.push( info );
+	}
+
+	error( info ) {
+		this.errors.push( info );
+	}
+}
 
 describe( 'src/newrelic', () => {
 	const OLD_ENV_VARS = process.env;
@@ -13,29 +30,39 @@ describe( 'src/newrelic', () => {
 
 	afterEach( () => {
 		process.env = OLD_ENV_VARS;
+		process.env.VIP_GO_APP_ID = 123; // Adding an ID to mimick VIP Go
 	} );
 
 	describe( 'Environment variables are missing', () => {
+		it( 'Should skip if local development environment', () => {
+			process.env.VIP_GO_APP_ID = '';
+			const transport = new TestTransport();
+			newrelic( { logger: transport } );
+
+			expect( transport.logs[ 0 ] ).toMatch( 'skipping Newrelic' );
+		} );
+
 		it( 'Should fail if NEW_RELIC_NO_CONFIG_FILE is not set', () => {
-			expect( () => {
-				newrelic();
-			} ).toThrowError( /NEW_RELIC_NO_CONFIG_FILE/ );
+			const transport = new TestTransport();
+			newrelic( { logger: transport } );
+
+			expect( transport.errors[ 0 ] ).toMatch( 'NEW_RELIC_NO_CONFIG_FILE' );
 		} );
 
 		it( 'Should fail if NEW_RELIC_NO_CONFIG_FILE is set to false', () => {
 			process.env.NEW_RELIC_NO_CONFIG_FILE = false;
+			const transport = new TestTransport();
+			newrelic( { logger: transport } );
 
-			expect( () => {
-				newrelic();
-			} ).toThrowError( /NEW_RELIC_NO_CONFIG_FILE/ );
+			expect( transport.errors[ 0 ] ).toMatch( 'NEW_RELIC_NO_CONFIG_FILE' );
 		} );
 
 		it( 'Should fail if NEW_RELIC_LICENSE_KEY is not set', () => {
 			process.env.NEW_RELIC_NO_CONFIG_FILE = true;
+			const transport = new TestTransport();
+			newrelic( { logger: transport } );
 
-			expect( () => {
-				newrelic();
-			} ).toThrowError( /NEW_RELIC_LICENSE_KEY/ );
+			expect( transport.errors[ 0 ] ).toMatch( 'NEW_RELIC_LICENSE_KEY' );
 		} );
 	} );
 
@@ -53,7 +80,7 @@ describe( 'src/newrelic', () => {
 			} ).toThrowError( /could not be imported/ );
 		} );
 
-		it( 'Should return newrelic module when config correct set', () => {
+		it( 'Should return newrelic module when config is correctly set', () => {
 			process.env.NEW_RELIC_NO_CONFIG_FILE = true;
 			process.env.NEW_RELIC_LICENSE_KEY = 'ABC';
 			const returnedValue = newrelic();

--- a/src/newrelic/index.js
+++ b/src/newrelic/index.js
@@ -2,6 +2,13 @@ module.exports = ( { logger = console } = {} ) => {
 	const licenseKey = process.env.NEW_RELIC_LICENSE_KEY;
 	const noConfig = process.env.NEW_RELIC_NO_CONFIG_FILE === 'true';
 
+	const isLocal = ! process.env.VIP_GO_APP_ID;
+
+	if ( isLocal ) {
+		logger.log( 'Local development, skipping Newrelic initialization...' );
+		return;
+	}
+
 	if ( ! noConfig ) {
 		throw new Error( `An environment variable is missing 
 			or not set to true: NEW_RELIC_NO_CONFIG_FILE` );

--- a/src/newrelic/index.js
+++ b/src/newrelic/index.js
@@ -5,19 +5,19 @@ module.exports = ( { logger = console } = {} ) => {
 	const isLocal = ! process.env.VIP_GO_APP_ID;
 
 	if ( isLocal ) {
-		logger.log( 'Local development, skipping Newrelic initialization...' );
+		logger.log( 'Local development, skipping New Relic initialization...' );
 		return;
 	}
 
 	if ( ! noConfig ) {
 		logger.error( `An environment variable is missing 
-			or not set to true: NEW_RELIC_NO_CONFIG_FILE. Skipping NewRelic initialization...` );
+			or not set to true: NEW_RELIC_NO_CONFIG_FILE. Skipping New Relic initialization...` );
 		return;
 	}
 
 	if ( ! licenseKey ) {
 		logger.error( `An environment variable is missing: 
-			NEW_RELIC_LICENSE_KEY. Skipping NewRelic initialization...` );
+			NEW_RELIC_LICENSE_KEY. Skipping New Relic initialization...` );
 		return;
 	}
 

--- a/src/newrelic/index.js
+++ b/src/newrelic/index.js
@@ -10,12 +10,15 @@ module.exports = ( { logger = console } = {} ) => {
 	}
 
 	if ( ! noConfig ) {
-		throw new Error( `An environment variable is missing 
-			or not set to true: NEW_RELIC_NO_CONFIG_FILE` );
+		logger.error( `An environment variable is missing 
+			or not set to true: NEW_RELIC_NO_CONFIG_FILE. Skipping NewRelic initialization...` );
+		return;
 	}
 
 	if ( ! licenseKey ) {
-		throw new Error( 'An environment variable is missing: NEW_RELIC_LICENSE_KEY' );
+		logger.error( `An environment variable is missing: 
+			NEW_RELIC_LICENSE_KEY. Skipping NewRelic initialization...` );
+		return;
 	}
 
 	logger.info( 'Importing New Relic library...' );


### PR DESCRIPTION
This skip newrelic in local and stops throwing when env vars are missing (replacing with logger.error and skipping initialization)

fix #121 
fix #122 