### PR TITLE
Drop Node 6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ workflows:
   build:
     jobs:
       - node-base
-      - node-6
       - node-8
       - node-10
 


### PR DESCRIPTION
## Description

This drops support for Node 6

## Steps to Test

No tests required
