### PR TITLE
preflight-checks: Don't run build-ci

### DIFF
--- a/preflight-checks/src/checks/02-check-port-and-healthcheck-route.js
+++ b/preflight-checks/src/checks/02-check-port-and-healthcheck-route.js
@@ -30,12 +30,7 @@ module.exports = {
 			.then( () => {
 				let buildingCommand = 'npm run build';
 
-				if ( scripts[ 'build-ci' ] ) {
-					buildingCommand = 'npm run build-ci';
-					console.log( chalk.blue( '  Info:' ), `Building the project with ${ chalk.yellow( 'npm run build-ci' ) }...` );
-				} else {
-					console.log( chalk.blue( '  Info:' ), `Building the project using ${ chalk.yellow( 'npm run build' ) }...` );
-				}
+				console.log( chalk.blue( '  Info:' ), `Building the project using ${ chalk.yellow( buildingCommand ) }...` );
 
 				return execa.shell( buildingCommand );
 			} )


### PR DESCRIPTION
Preflights are expected to run on production-ready code and build-ci can provide incorrect results. 

An example this came up:

- A broken version of a built app was provided. This version had both `build-ci` and `build` steps.
- Preflight checks were run.
- Because the app had the `build-ci` step, the preflight check ran the step, which generated a fixed version of the app.
- Tests passed.

However, on production, we don't run the `build-ci` step so we attempted to run the broken version instead and 🔥 

## Steps to Test

1. `cd preflight-checks`
1. `npm run build`
1. Clone https://github.com/Automattic/vip-go-node-skeleton
1. Go to the cloned directory
1. Run `/path/to/preflight-checks/dist/index.js`

Verify all checks pass.