### PR TITLE
Fix link to homepage in package.json

### DIFF
--- a/preflight-checks/package.json
+++ b/preflight-checks/package.json
@@ -17,7 +17,7 @@
   "bugs": {
     "url": "https://github.com/Automattic/vip-go-node/issues"
   },
-  "homepage": "https://github.com/Automattic/vip-go-node/preflight-checks#readme",
+  "homepage": "https://github.com/Automattic/vip-go-node/blob/master/preflight-checks/README.md",
   "devDependencies": {
     "@babel/cli": "7.5.5",
     "@babel/preset-env": "7.5.5",


### PR DESCRIPTION
## Description

"Homepage" link in package.json (and therefore on npmjs.com) was previously 404.