### PR TITLE
Fix babel runtime import in redis module

### DIFF
--- a/src/redis/index.js
+++ b/src/redis/index.js
@@ -26,7 +26,9 @@ const getConnectionInfo = () => {
 	let port = null;
 	// Must be in the format `host:port`
 	if ( hostAndPort && hostAndPort.match( /^[\w\-\_\.]+:\d+$/ ) ) {
-		[ host, port ] = hostAndPort.split( ':' );
+		const splitted = hostAndPort.split( ':' );
+		host = splitted[ 0 ];
+		port = splitted[ 1 ];
 	}
 
 	return { host, port, password };


### PR DESCRIPTION
## Description

It looks like after babel builds the code, the dist folder have imports for `@babel/runtime`: `require("@babel/runtime/helpers/interopRequireDefault")`. We don't install babel in production environments, and thus, it makes the module fail.

Digging into this, it's coming from the array deconstruction which is what this PR fixes. I tried to change our presets, but nothing worked to remove the import.

## Steps to Test

Outline the steps to test and verify the PR here.

*Before cloning this PR*

1. Get master
1. Build it using `npm run build`
1. Double check `require("@babel/runtime/helpers/interopRequireDefault")` is showing in `dist/redis/index.js`

*After cloning this PR*

1. Check out PR.
1. Run `npm run build`.
1. Double check there is no mention of `require("@babel/runtime/helpers/interopRequireDefault")`

