### PR TITLE
Adding options to the VIP Go Node Preflight Checks command

### DIFF
--- a/preflight-checks/package-lock.json
+++ b/preflight-checks/package-lock.json
@@ -3359,7 +3359,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -3409,8 +3408,7 @@
     "array-back": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "dev": true
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
     },
     "array-equal": {
       "version": "1.0.0",
@@ -4047,7 +4045,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -4055,8 +4052,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -4071,12 +4067,44 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
       "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
-      "dev": true,
       "requires": {
         "array-back": "^3.0.1",
         "find-replace": "^3.0.0",
         "lodash.camelcase": "^4.3.0",
         "typical": "^4.0.0"
+      }
+    },
+    "command-line-usage": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
+      "integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
+      "requires": {
+        "array-back": "^4.0.1",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.1",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+          "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
       }
     },
     "commander": {
@@ -4240,6 +4268,11 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -4426,8 +4459,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.13.0",
@@ -4718,7 +4750,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
       "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "dev": true,
       "requires": {
         "array-back": "^3.0.1"
       }
@@ -4932,8 +4963,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -7495,8 +7525,7 @@
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -8289,6 +8318,11 @@
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
       }
+    },
+    "reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
     },
     "regenerate": {
       "version": "1.4.0",
@@ -9095,7 +9129,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -9132,6 +9165,29 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "table-layout": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
+      "integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
+      "requires": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+          "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
     },
     "terminal-link": {
       "version": "2.1.1",
@@ -9336,8 +9392,7 @@
     "typical": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "dev": true
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -9578,6 +9633,22 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
+    },
+    "wordwrapjs": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
+      "integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
+      "requires": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.0.0"
+      },
+      "dependencies": {
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
     },
     "wrap-ansi": {
       "version": "6.2.0",

--- a/preflight-checks/package-lock.json
+++ b/preflight-checks/package-lock.json
@@ -3406,6 +3406,12 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "dev": true
+    },
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
@@ -4061,6 +4067,18 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "command-line-args": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "dev": true,
+      "requires": {
+        "array-back": "^3.0.1",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      }
+    },
     "commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -4694,6 +4712,15 @@
             "is-extendable": "^0.1.0"
           }
         }
+      }
+    },
+    "find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dev": true,
+      "requires": {
+        "array-back": "^3.0.1"
       }
     },
     "find-up": {
@@ -7465,6 +7492,12 @@
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -9299,6 +9332,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/preflight-checks/package.json
+++ b/preflight-checks/package.json
@@ -21,7 +21,6 @@
   "devDependencies": {
     "@babel/cli": "^7.12.1",
     "@babel/preset-env": "7.8.4",
-    "command-line-args": "^5.1.1",
     "jest": "25.1.0",
     "publish-please": "^5.5.2"
   },
@@ -30,6 +29,8 @@
     "execa": "^4.0.0",
     "node-fetch": "^2.6.1",
     "rmfr": "^2.0.0",
-    "waait": "^1.0.4"
+    "waait": "^1.0.4",
+    "command-line-args": "^5.1.1",
+    "command-line-usage": "^6.1.1"
   }
 }

--- a/preflight-checks/package.json
+++ b/preflight-checks/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@babel/cli": "^7.12.1",
     "@babel/preset-env": "7.8.4",
+    "command-line-args": "^5.1.1",
     "jest": "25.1.0",
     "publish-please": "^5.5.2"
   },

--- a/preflight-checks/src/checks/02-check-port-and-healthcheck-route.js
+++ b/preflight-checks/src/checks/02-check-port-and-healthcheck-route.js
@@ -1,6 +1,4 @@
 import chalk from 'chalk';
-import packageJson from '../package';
-import commandLineArgs from 'command-line-args';
 const execa = require( 'execa' );
 const waait = require( 'waait' );
 const fetch = require( 'node-fetch' );
@@ -21,17 +19,10 @@ const executeShell = ( command, envVars = {} ) => {
 	} );
 }
 
-const optionDefinitions = [
-	{ name: 'wait', alias: 'w', type: Number, defaultOption: 3000 },
-	{ name: 'verbose', type: Boolean, defaultOption: false },
-];
-
-const options = commandLineArgs( optionDefinitions );
-
 module.exports = {
 	name: `Building the app and running ${ chalkNpmStart }...`,
 	excerpt: `Checking if your app accepts a ${ chalkPORT } and responds to ${ chalkHealthCheckRoute }`,
-	run: async () => {
+	run: async ( packageJson, { wait, verbose } ) => {
 		const PORT = Math.floor( Math.random() * ( 4000 - 3000 ) + 3000 ); // Get a PORT between 3000 and 4000
 
 		let subprocess;
@@ -48,7 +39,7 @@ module.exports = {
 					VIP_GO_APP_ID: '20030527',
 				} );
 
-				if ( options.verbose ) {
+				if ( verbose ) {
 					subprocess.stdout.pipe( process.stdout );
 				}
 
@@ -60,11 +51,11 @@ module.exports = {
 					PORT: PORT,
 				} );
 
-				if ( options.verbose ) {
+				if ( verbose ) {
 					subprocess.stdout.pipe( process.stdout );
 				}
 
-				await waait( options.wait ); // Wait a little before resolving, giving time for the server to boot up
+				await waait( wait ); // Wait a little before resolving, giving time for the server to boot up
 
 				const cacheUrl = `http://localhost:${ PORT }${ CACHE_HEALTHCHECK_ROUTE }`;
 				console.log( chalk.blue( '  Info:' ), `Sending a GET request to ${ cacheUrl }...` );

--- a/preflight-checks/src/checks/02-check-port-and-healthcheck-route.js
+++ b/preflight-checks/src/checks/02-check-port-and-healthcheck-route.js
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import packageJson from '../package';
+import commandLineArgs from 'command-line-args';
 const execa = require( 'execa' );
 const waait = require( 'waait' );
 const fetch = require( 'node-fetch' );
@@ -9,11 +10,6 @@ const chalkNpmStart = chalk.yellow( 'npm start' );
 const chalkPORT = chalk.yellow( 'PORT' );
 const chalkHealthCheckRoute = chalk.yellow( CACHE_HEALTHCHECK_ROUTE );
 const chalkVIPGo = chalk.yellow( '@automattic/vip-go' );
-const rmfr = require('rmfr');
-
-const currentWorkingDirectory = process.cwd();
-const path = require( 'path' );
-const node_modules = path.join( currentWorkingDirectory, 'node_modules' );
 
 const envVariables = {
 	'VIP_GO_APP_ID': '123',
@@ -25,11 +21,16 @@ const executeShell = ( command, envVars = {} ) => {
 	} );
 }
 
+const optionDefinitions = [
+	{ name: 'wait', alias: 'w', type: Number, defaultOption: 3000 },
+];
+
+const options = commandLineArgs( optionDefinitions );
+
 module.exports = {
 	name: `Building the app and running ${ chalkNpmStart }...`,
 	excerpt: `Checking if your app accepts a ${ chalkPORT } and responds to ${ chalkHealthCheckRoute }`,
 	run: async () => {
-		const scripts = packageJson.scripts;
 		const PORT = Math.floor( Math.random() * ( 4000 - 3000 ) + 3000 ); // Get a PORT between 3000 and 4000
 
 		let subprocess;
@@ -51,7 +52,8 @@ module.exports = {
 				subprocess = executeShell( 'npm start', {
 					PORT: PORT,
 				} );
-				await waait( 3000 ); // Wait a little before resolving, giving time for the server to boot up
+
+				await waait( options.wait ); // Wait a little before resolving, giving time for the server to boot up
 
 				const cacheUrl = `http://localhost:${ PORT }${ CACHE_HEALTHCHECK_ROUTE }`;
 				console.log( chalk.blue( '  Info:' ), `Sending a GET request to ${ cacheUrl }...` );

--- a/preflight-checks/src/checks/02-check-port-and-healthcheck-route.js
+++ b/preflight-checks/src/checks/02-check-port-and-healthcheck-route.js
@@ -23,6 +23,7 @@ const executeShell = ( command, envVars = {} ) => {
 
 const optionDefinitions = [
 	{ name: 'wait', alias: 'w', type: Number, defaultOption: 3000 },
+	{ name: 'verbose', type: Boolean, defaultOption: false },
 ];
 
 const options = commandLineArgs( optionDefinitions );
@@ -43,15 +44,25 @@ module.exports = {
 
 				console.log( chalk.blue( '  Info:' ), `Building the project using ${ chalk.yellow( buildingCommand ) }...` );
 
-				return executeShell( buildingCommand, {
+				subprocess = executeShell( buildingCommand, {
 					VIP_GO_APP_ID: '20030527',
 				} );
+
+				if ( options.verbose ) {
+					subprocess.stdout.pipe( process.stdout );
+				}
+
+				return subprocess;
 			} )
 			.then( async () => {
 				console.log( chalk.blue( '  Info:' ), `Running ${ chalk.yellow( 'npm start' ) } to launch your app on PORT: ${ PORT }...` );
 				subprocess = executeShell( 'npm start', {
 					PORT: PORT,
 				} );
+
+				if ( options.verbose ) {
+					subprocess.stdout.pipe( process.stdout );
+				}
 
 				await waait( options.wait ); // Wait a little before resolving, giving time for the server to boot up
 

--- a/preflight-checks/src/index.js
+++ b/preflight-checks/src/index.js
@@ -36,13 +36,13 @@ const optionsSections = [
 				alias: 'w',
 				typeLabel: '{underline Number}',
 				defaultOption: '3000',
-				description: 'Configure wait time for server boot up'
+				description: 'Configure time to wait (in milliseconds) for command to execute'
 			},
 			{
 				name: 'verbose',
 				typeLabel: '{underline Boolean}',
 				defaultOption: 'false',
-				description: 'Print application server build and boot-up messages'
+				description: 'Increase logging level to include app build and server boot up messages'
 			},
 			{
 				name: 'help',

--- a/preflight-checks/src/index.js
+++ b/preflight-checks/src/index.js
@@ -2,8 +2,8 @@
 import chalk from 'chalk';
 import checks from './checks';
 import packageJson from './package';
-
-const appName = packageJson.name;
+import commandLineArgs from 'command-line-args';
+import commandLineUsage from 'command-line-usage';
 
 console.log();
 console.log( '  Welcome to' );
@@ -14,7 +14,50 @@ console.log( '  | |/ // // ____/  / /_/ / /_/ /' );
 console.log( '  |___/___/_/       \\____/\\____/' );
 console.log( '  Preflight Checks for Node Apps' );
 console.log();
-console.log( `  Running checks for the ${ appName } app...` );
+
+const optionDefinitions = [
+	{ name: 'wait', alias: 'w', type: Number, defaultOption: 3000 },
+	{ name: 'verbose', type: Boolean, defaultOption: false },
+	{ name: 'help', alias: 'h', type: Boolean },
+];
+
+const options = commandLineArgs( optionDefinitions );
+
+const optionsSections = [
+	{
+		header: 'VIP Go Node Preflight Checks',
+		content: 'Run preflight checks on Node applications on VIP Go Cloud'
+	},
+	{
+		header: 'Options',
+		optionList: [
+			{
+				name: 'wait',
+				alias: 'w',
+				typeLabel: '{underline Number}',
+				defaultOption: '3000',
+				description: 'Configure wait time for server boot up'
+			},
+			{
+				name: 'verbose',
+				typeLabel: '{underline Boolean}',
+				defaultOption: 'false',
+				description: 'Print application server build and boot-up messages'
+			},
+			{
+				name: 'help',
+				description: 'Print this usage guide'
+			}
+		]
+	}
+];
+
+if ( options.help ) {
+	console.log( commandLineUsage( optionsSections ) );
+	process.exit();
+}
+
+console.log( `  Running checks for the ${ packageJson.name } app...` );
 console.log();
 console.log();
 
@@ -27,7 +70,7 @@ const result = checks.reduce( async ( priorCheck, check, index ) => {
 	console.log( `  [ Step ${ index + 1 }/${ checks.length } ] ${ check.name }` );
 	console.log( `  [ Step ${ index + 1 }/${ checks.length } ] Step details: ${ check.excerpt }` );
 
-	const currentCheck = await check.run().then( result => {
+	const currentCheck = await check.run( packageJson, options ).then( result => {
 		// Success
 		if ( result === 'success' ) {
 			const message = `[ Step ${ index + 1 }/${ checks.length } ] ${ chalk.green( 'Step successful' ) } 👍`;


### PR DESCRIPTION
## Description

This PR adds the following command options for the VIP Go Node Preflight Checks command:
- `--wait=3000` or `-w 3000`: Time in milliseconds to wait for command to execute (default is 3000)
- `--verbose`: Increase logging level to include app build and server boot up messages
- `--help` or `-h`: command usage guide (default is false)

## Steps to Test

1. Check out PR.
1. Run `npm run build`.
1. Go to your target node app and run the following in the app's root directory `node <path_to_preflight_checks_repo>/dist/index.js` 
1. Verify that all the command options work as expected

