### PR TITLE
Update preflight checks to fix issues and match new requirements

### DIFF
--- a/preflight-checks/src/checks/02-check-port-and-healthcheck-route.js
+++ b/preflight-checks/src/checks/02-check-port-and-healthcheck-route.js
@@ -4,7 +4,16 @@ const waait = require( 'waait' );
 const fetch = require( 'node-fetch' );
 
 const CACHE_HEALTHCHECK_ROUTE = '/cache-healthcheck?';
-const chalkNpmStart = chalk.yellow( 'npm start' );
+
+// Commands
+const npmPrune = 'npm prune --production'; // Make sure no extra dependencies are installed
+const npmInstall = 'npm install --production';
+const npmBuild = 'npm run build';
+const npmStart = 'npm start';
+
+const chalkNpmInstall = chalk.yellow( npmInstall );
+const chalkNpmBuild = chalk.yellow( npmBuild );
+const chalkNpmStart = chalk.yellow( npmStart );
 const chalkPORT = chalk.yellow( 'PORT' );
 const chalkHealthCheckRoute = chalk.yellow( CACHE_HEALTHCHECK_ROUTE );
 const chalkVIPGo = chalk.yellow( '@automattic/vip-go' );
@@ -20,22 +29,22 @@ const executeShell = ( command, envVars = {} ) => {
 }
 
 module.exports = {
-	name: `Building the app and running ${ chalkNpmStart }...`,
+	name: 'Installing dependencies, building, and starting your app',
 	excerpt: `Checking if your app accepts a ${ chalkPORT } and responds to ${ chalkHealthCheckRoute }`,
-	run: async ( packageJson, { wait, verbose } ) => {
-		const PORT = Math.floor( Math.random() * ( 4000 - 3000 ) + 3000 ); // Get a PORT between 3000 and 4000
+	run: ( packageJson, { wait, verbose } ) => {
+		const PORT = Math.floor( Math.random() * 1000 ) + 3001; // Get a PORT from 3001 and 3999
 
 		let subprocess;
 
-		console.log( chalk.blue( '  Info:' ), `Installing production dependencies with ${ chalk.yellow( 'npm install --production' ) }...` );
+		console.log( chalk.blue( '  Info:' ), `Installing dependencies using ${ chalkNpmInstall }...` );
 
-		return executeShell( 'npm install --production' )
+		return executeShell( npmPrune )
+			.then( () => executeShell( npmInstall ) )
 			.then( () => {
-				let buildingCommand = 'npm run build';
+				console.log( chalk.blue( '  Info:' ), `Building the project using ${ chalkNpmBuild }...` );
 
-				console.log( chalk.blue( '  Info:' ), `Building the project using ${ chalk.yellow( buildingCommand ) }...` );
-
-				subprocess = executeShell( buildingCommand, {
+				subprocess = executeShell( npmBuild, {
+					NODE_ENV: 'production',
 					VIP_GO_APP_ID: '20030527',
 				} );
 
@@ -46,8 +55,9 @@ module.exports = {
 				return subprocess;
 			} )
 			.then( async () => {
-				console.log( chalk.blue( '  Info:' ), `Running ${ chalk.yellow( 'npm start' ) } to launch your app on PORT: ${ PORT }...` );
-				subprocess = executeShell( 'npm start', {
+				console.log( chalk.blue( '  Info:' ), `Running your app with ${ chalkNpmStart } on PORT: ${ PORT }...` );
+				subprocess = executeShell( npmStart, {
+					NODE_ENV: 'production',
 					PORT: PORT,
 				} );
 

--- a/preflight-checks/src/checks/index.js
+++ b/preflight-checks/src/checks/index.js
@@ -1,5 +1,6 @@
 module.exports = [
 	require( './00-npm-scripts.js' ),
-	require( './01-vip-go-package.js' ),
+	// Disabled until we can formalize what we will require
+	// require( './01-vip-go-package.js' ),
 	require( './02-check-port-and-healthcheck-route.js' ),
 ];

--- a/preflight-checks/src/index.js
+++ b/preflight-checks/src/index.js
@@ -16,8 +16,8 @@ console.log( '  Preflight Checks for Node Apps' );
 console.log();
 
 const optionDefinitions = [
-	{ name: 'wait', alias: 'w', type: Number, defaultOption: 3000 },
-	{ name: 'verbose', type: Boolean, defaultOption: false },
+	{ name: 'wait', alias: 'w', type: Number, defaultValue: 3000 },
+	{ name: 'verbose', type: Boolean, defaultValue: false },
 	{ name: 'help', alias: 'h', type: Boolean },
 ];
 
@@ -26,7 +26,7 @@ const options = commandLineArgs( optionDefinitions );
 const optionsSections = [
 	{
 		header: 'VIP Go Node Preflight Checks',
-		content: 'Run preflight checks on Node applications on VIP Go Cloud'
+		content: 'Run preflight checks on Node.js applications on VIP Go'
 	},
 	{
 		header: 'Options',
@@ -70,7 +70,7 @@ const result = checks.reduce( async ( priorCheck, check, index ) => {
 	console.log( `  [ Step ${ index + 1 }/${ checks.length } ] ${ check.name }` );
 	console.log( `  [ Step ${ index + 1 }/${ checks.length } ] Step details: ${ check.excerpt }` );
 
-	const currentCheck = await check.run( packageJson, options ).then( result => {
+	return check.run( packageJson, options ).then( result => {
 		// Success
 		if ( result === 'success' ) {
 			const message = `[ Step ${ index + 1 }/${ checks.length } ] ${ chalk.green( 'Step successful' ) } 👍`;
@@ -94,7 +94,6 @@ const result = checks.reduce( async ( priorCheck, check, index ) => {
 		console.log();
 		console.log();
 	} );
-	return currentCheck;
 }, Promise.resolve() );
 
 result.then( () => {


### PR DESCRIPTION
## Description

- Fixes default option values so that they are respected. In particular, this provides a working default `wait` option.
- Disables the check for `@automattic/vip-go` since it is no longer required.
- Adds a `npm prune --production` step that will remove any extra dependencies that are locally installed but not listed as `dependencies`. This helps flag the common problem of a dependency being installed with `--save-dev` or without `--save`.
- Improves `PORT` randomness by preventing the possibility of the app starting on `3000` or `4000`, both common defaults.

## Steps to Test

1. Check out PR.
1. Run `npm test`.