### PR TITLE
fix: incorrect version bump in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automattic/vip-go",
-  "version": "1.2.0-dev",
+  "version": "1.1.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automattic/vip-go",
-      "version": "1.2.0-dev",
+      "version": "1.1.0-dev",
       "license": "ISC",
       "dependencies": {
         "winston": "3.10.0"


### PR DESCRIPTION
## Description
Fixes a unintended version bump in the package-lock.json reverts from 1.2.0-dev to 1.1.0-dev