### PR TITLE
fix(build): remove `src` from `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -23,9 +23,6 @@ node_modules/
 .ackrc
 .publishrc
 
-# ES6 source folder
-src
-
 # Hooks
 hooks
 


### PR DESCRIPTION
## Description

This change removes the `src` folder from `.npmignore` to fix the issue with publishing.

In 2b0a33e6a32263b6b24a593ab6b8459d4ef634dc, we removed the build step and, as a consequence, the `dist` folder became useless: the package was meant to be published from `src`.

However, because we failed to update `.npmignore`, we did not publish the source code, and the 1.2.0 release became broken.

Fixes: PLTFRM-1545

## Steps to Test

`npm pack` before:
```
$ npm pack
npm notice
npm notice 📦  @automattic/vip-go@1.2.1-dev.0
npm notice Tarball Contents
npm notice 173B .editorconfig
npm notice 23B .eslintignore
npm notice 128B .eslintrc.js
npm notice 45B .prettierrc
npm notice 1.0kB CONTRIBUTING.md
npm notice 1.9kB README.md
npm notice 138B docker-compose.yml
npm notice 1.3kB package.json
npm notice Tarball Details
npm notice name: @automattic/vip-go
npm notice version: 1.2.1-dev.0
npm notice filename: automattic-vip-go-1.2.1-dev.0.tgz
npm notice package size: 2.3 kB
npm notice unpacked size: 4.8 kB
npm notice shasum: fc6b75ed67c4541a392c708907e72c1fffc710ed
npm notice integrity: sha512-DEHiQq4lX+dKl[...]NRYsnOTJlzwFA==
npm notice total files: 8
```

`npm pack` after:
```
$ npm pack
npm notice
npm notice 📦  @automattic/vip-go@1.2.1-dev.0
npm notice Tarball Contents
npm notice 173B .editorconfig
npm notice 23B .eslintignore
npm notice 128B .eslintrc.js
npm notice 45B .prettierrc
npm notice 1.0kB CONTRIBUTING.md
npm notice 1.9kB README.md
npm notice 138B docker-compose.yml
npm notice 1.3kB package.json
npm notice 218B src/index.js
npm notice 3.0kB src/logger/index.js
npm notice 4.5kB src/logger/README.md
npm notice 976B src/newrelic/index.js
npm notice 905B src/newrelic/README.md
npm notice 2.4kB src/redis/index.js
npm notice 1.4kB src/redis/README.md
npm notice 981B src/server/index.js
npm notice 2.7kB src/server/README.md
npm notice Tarball Details
npm notice name: @automattic/vip-go
npm notice version: 1.2.1-dev.0
npm notice filename: automattic-vip-go-1.2.1-dev.0.tgz
npm notice package size: 8.0 kB
npm notice unpacked size: 21.8 kB
npm notice shasum: ae7086d3dab83cf86ea06a7854c6f6232b840e0d
npm notice integrity: sha512-JvMk+UM44l8Nw[...]gJn0DnWwK8Law==
npm notice total files: 17
```
