### PR TITLE
fix: remove deprecated `version` from `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   parker_redis:
     container_name: redis


### PR DESCRIPTION
This PR fixes this warning:

```
WARN[0000] docker-compose.yml: `version` is obsolete
```
