### PR TITLE
docs: add project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Please refer the documentation for each module ([`server`](https://github.com/Au
 
 New Relic is no longer a peer dependency of this module. Please remember to install [New Relic](https://docs.newrelic.com/docs/agents/manage-apm-agents/installation/install-agent) separately if your app requires it.
 
+## Reference docs
+
+- [Architecture](docs/ARCHITECTURE.md)
+- [Environment](docs/ENVIRONMENT.md)
+- [Testing](docs/TESTING.md)
+
 ## Development
 
 ### Using hooks

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,203 @@
+# Architecture
+
+## Purpose
+
+This document describes the runtime shape of `@automattic/vip-go`, the package helpers it exposes, and the boundaries each helper owns. It is intended for maintainers, reviewers, and downstream consumers that need a quick mental model before changing the package.
+
+## Package role
+
+`@automattic/vip-go` is a small helper package for Node.js applications running on VIP Go. It provides shared runtime primitives for HTTP serving, logging, New Relic bootstrapping, and Redis connection setup.
+
+The package is not an application framework and does not own product logic. Consumers remain responsible for routing, authorization, request validation, error handling, and application-specific observability.
+
+## Public entrypoint
+
+The package root exports an object from `src/index.ts`:
+
+```ts
+import logger from './logger';
+import newrelic from './newrelic';
+import redis from './redis';
+import server from './server';
+
+export = {
+	logger,
+	server,
+	newrelic,
+	redis,
+};
+```
+
+Runtime consumers commonly use CommonJS:
+
+```js
+const { server, logger, newrelic, redis } = require( '@automattic/vip-go' );
+```
+
+Type consumers can import helper types from the `./types` export:
+
+```ts
+import type { RedisOptions } from '@automattic/vip-go/types';
+```
+
+## Build and package output
+
+Source is authored in TypeScript and compiled to CommonJS JavaScript under `dist/`.
+
+Important package metadata:
+
+- `main`: `./dist/src/index.js`
+- `types`: `./dist/src/index.d.ts`
+- package root export: `./dist/src/index.js` plus `./dist/src/index.d.ts`
+- `./types` export: `./dist/src/types/index.js` plus `./dist/src/types/index.d.ts`
+- published files: `dist/src/`
+
+The TypeScript compiler is configured for strict checking and declaration emit. The build command is:
+
+```sh
+npm run build
+```
+
+## Module map
+
+### `server`
+
+Source: `src/server/index.ts`
+
+The `server` helper wraps a request handler or Express-compatible app with a Node HTTP server.
+
+Responsibilities:
+
+- Require a request handler.
+- Create an HTTP server with `node:http.createServer`.
+- Add a built-in `/cache-healthcheck?` route that returns `200` and `ok`.
+- Forward all non-healthcheck requests to the provided app/request handler.
+- Return a wrapped application object with `app`, `server`, `listen`, and `close`.
+- Resolve the listen port from the explicit `PORT` option, then `process.env.PORT`, then `3000`.
+
+Boundary:
+
+- The helper does not define application routes beyond `/cache-healthcheck?`.
+- Consumers own routing, HTTP semantics, authentication, and request validation.
+
+### `logger`
+
+Source: `src/logger/index.ts`
+
+The `logger` helper creates a Winston logger with VIP-oriented log labels and environment-sensitive formatting.
+
+Responsibilities:
+
+- Require a namespace such as `app:component`.
+- Derive `app` and `app_type` labels from the namespace.
+- Add `message_type`, `app_process`, and `app_worker` labels.
+- Use local text formatting when `VIP_GO_APP_ID` is absent.
+- Use production JSON-like formatting when `VIP_GO_APP_ID` is present.
+- Set log level to `debug` in local mode and `info` in VIP mode.
+- Support custom Winston transport, cluster implementation, and per-logger silence option.
+- Support default global silencing via `VIP_GO_SILENCE_LOGS=1`.
+
+Boundary:
+
+- The helper normalizes log shape but does not enforce redaction or application-specific logging policy.
+- Consumers must avoid logging secrets and sensitive request payloads.
+
+### `newrelic`
+
+Source: `src/newrelic/index.ts`
+
+The `newrelic` helper conditionally loads the `newrelic` package for VIP runtime environments.
+
+Responsibilities:
+
+- Treat absent `VIP_GO_APP_ID` as local development and skip initialization.
+- Require `NEW_RELIC_NO_CONFIG_FILE=true` outside local mode.
+- Require `NEW_RELIC_LICENSE_KEY` outside local mode.
+- Dynamically require the `newrelic` package only after environment checks pass.
+- Return the loaded New Relic module when initialization succeeds.
+- Log missing configuration and skip initialization instead of throwing for missing env vars.
+- Throw if the `newrelic` package cannot be imported after configuration is valid.
+
+Boundary:
+
+- `newrelic` is not a package dependency. Applications that need it must install it.
+- This helper bootstraps the agent; it does not define application-specific New Relic instrumentation.
+
+### `redis`
+
+Source: `src/redis/index.ts`
+
+The `redis` helper creates a singleton `ioredis` client using VIP Redis environment variables.
+
+Responsibilities:
+
+- Expose `redis()` for client creation.
+- Expose `redis.getConnectionInfo()` for bring-your-own-client scenarios.
+- Read `REDIS_MASTER` as `host:port`.
+- Read `REDIS_PASSWORD` and pass it to the client options.
+- Use `QUEUED_CONNECTION_ATTEMPTS` as `maxRetriesPerRequest`, defaulting to `3`.
+- Enable offline queue by default.
+- Re-enable offline queue on connect.
+- Disable offline queue on reconnect once max retry behavior is reached.
+- Attach connect, reconnecting, error, and disconnect log handlers.
+- Dynamically require `ioredis` only when a valid host and port are present.
+
+Boundary:
+
+- `ioredis` is not a production dependency of this package. Applications using Redis must install it.
+- The helper standardizes client creation but does not own cache semantics, key design, or command-level retry policy beyond the configured client options.
+
+## Runtime mode model
+
+`VIP_GO_APP_ID` is the shared signal for local versus VIP runtime behavior:
+
+- absent: local mode
+- present: VIP mode
+
+Effects:
+
+- `logger` switches formatting and log level.
+- `newrelic` skips initialization in local mode.
+
+`server` and `redis` do not use `VIP_GO_APP_ID` directly for runtime branching.
+
+## External dependencies
+
+Runtime dependency:
+
+- `winston`: logger implementation.
+
+Consumer-installed optional dependencies:
+
+- `newrelic`: required by consumers that call `newrelic()` in VIP mode.
+- `ioredis`: required by consumers that call `redis()` with a valid Redis endpoint.
+
+Development and test dependencies include TypeScript, `ts-node`, Express, `ioredis`, Winston transport types, Node types, and formatting/linting tools.
+
+## Compatibility notes
+
+- Package output is CommonJS.
+- Source uses TypeScript with `export =` compatibility patterns.
+- Consumers should prefer the package root export and the documented `./types` export.
+- Legacy imports from build output paths, such as `@automattic/vip-go/dist/...`, should be treated as compatibility-sensitive because they couple consumers to package internals.
+
+## Change-risk map
+
+High-risk areas:
+
+- `src/server/index.ts`: changes can affect service startup and healthcheck behavior.
+- `src/logger/index.ts`: changes can affect Kibana/log search shape and incident visibility.
+- `src/newrelic/index.ts`: changes can silently disable or alter APM initialization.
+- `src/redis/index.ts`: changes can affect cache connectivity, queued commands, and reconnect behavior.
+- `package.json` exports and `files`: changes can break published package resolution or TypeScript declarations.
+
+Lower-risk areas:
+
+- README-only examples, as long as they match runtime behavior.
+- Test helper transport code, as long as it remains aligned with Winston transport behavior.
+
+## Related docs
+
+- [Environment](ENVIRONMENT.md)
+- [Testing](TESTING.md)
+- [Root README](../README.md)

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,0 +1,268 @@
+# Environment
+
+## Purpose
+
+This document lists every environment variable read by `@automattic/vip-go` runtime helpers, explains how each variable affects behavior, and separates runtime variables from documentation/test-only references.
+
+## Runtime variables
+
+### `PORT`
+
+Used by: `server`
+
+Source: `src/server/index.ts`
+
+Default: `3000`
+
+The `server` helper resolves its listening port in this order:
+
+1. explicit `PORT` option passed to `server( app, { PORT } )`
+2. `process.env.PORT`
+3. `3000`
+
+Example:
+
+```js
+const { server } = require( '@automattic/vip-go' );
+const appServer = server( app, { PORT: process.env.PORT || 8000 } );
+appServer.listen();
+```
+
+Operational notes:
+
+- VIP Go servers are expected to provide `PORT`.
+- Local development can either set `PORT` or pass an explicit option.
+- The helper always exposes `/cache-healthcheck?` on the selected port after listen starts.
+
+### `NODEJS_APP_PROCESS`
+
+Used by: `logger`
+
+Source: `src/logger/index.ts`
+
+Default: `master`
+
+The logger reads `NODEJS_APP_PROCESS` at module load time and includes it in structured log output as `app_process`.
+
+Operational notes:
+
+- Use this variable when a runtime has multiple app process roles and logs need to distinguish them.
+- If unset, logs use `app_process: "master"`.
+- Because it is read at module load time, set it before importing or requiring the logger helper.
+
+### `VIP_GO_SILENCE_LOGS`
+
+Used by: `logger`
+
+Source: `src/logger/index.ts`
+
+Default: unset, logging enabled
+
+When `VIP_GO_SILENCE_LOGS=1`, logger instances default to `silent: true` unless the caller explicitly passes a different `silent` option.
+
+Example:
+
+```sh
+VIP_GO_SILENCE_LOGS=1 npm test
+```
+
+Operational notes:
+
+- This is useful for quiet test output.
+- Avoid setting it in production unless log suppression is intentional.
+- Accidentally setting this variable can reduce incident visibility.
+
+### `VIP_GO_APP_ID`
+
+Used by: `logger`, `newrelic`
+
+Sources: `src/logger/index.ts`, `src/newrelic/index.ts`
+
+Default: unset, treated as local development
+
+`VIP_GO_APP_ID` is the package-level runtime mode signal.
+
+When absent:
+
+- `logger` uses local text formatting.
+- `logger` uses `debug` log level.
+- `newrelic` logs that local development is detected and skips initialization.
+
+When present:
+
+- `logger` uses production JSON-like formatting.
+- `logger` uses `info` log level.
+- `newrelic` requires the New Relic environment variables before importing the agent.
+
+Operational notes:
+
+- Tests set this variable to mimic VIP Go behavior.
+- Downstream apps should make sure the value is present in VIP runtime environments before depending on production logging or New Relic behavior.
+
+### `NEW_RELIC_NO_CONFIG_FILE`
+
+Used by: `newrelic`
+
+Source: `src/newrelic/index.ts`
+
+Required value: `true`
+
+Outside local mode, `newrelic()` requires `NEW_RELIC_NO_CONFIG_FILE=true`. If it is unset or set to any value other than the string `true`, the helper logs an error and skips initialization.
+
+Example:
+
+```sh
+NEW_RELIC_NO_CONFIG_FILE=true
+```
+
+Operational notes:
+
+- This allows New Relic to initialize from environment variables instead of a config file.
+- The check is strict: `true` works, `false` and missing values do not.
+
+### `NEW_RELIC_LICENSE_KEY`
+
+Used by: `newrelic`
+
+Source: `src/newrelic/index.ts`
+
+Default: none
+
+Outside local mode, after `NEW_RELIC_NO_CONFIG_FILE=true` is confirmed, `newrelic()` requires `NEW_RELIC_LICENSE_KEY`. If it is missing, the helper logs an error and skips initialization.
+
+Operational notes:
+
+- Required for New Relic initialization in VIP runtime mode.
+- Treat this value as a secret.
+- Do not log it or include it in test fixtures beyond dummy values.
+
+### `REDIS_MASTER`
+
+Used by: `redis`
+
+Source: `src/redis/index.ts`
+
+Expected format: `host:port`
+
+The Redis helper reads `REDIS_MASTER`, parses it as `host:port`, and returns `{ host, port, password }` from `redis.getConnectionInfo()`.
+
+Valid examples from tests:
+
+```text
+host:123
+123:123
+127.0.0.1:3379
+HOST_name.go-vip.co:123
+```
+
+Invalid examples from tests:
+
+```text
+
+abcdefg
+:123
+host:
+host:abcd
+host$name:123
+```
+
+Behavior:
+
+- If `REDIS_MASTER` is missing or malformed, `redis()` logs an error and returns `undefined`.
+- If `REDIS_MASTER` is valid, `redis()` dynamically imports `ioredis` and creates a singleton client.
+
+Operational notes:
+
+- Set this variable in local environments that use the Redis helper.
+- Keep the value to a single host and numeric port.
+- The helper does not parse multiple hosts or replica lists.
+
+### `REDIS_PASSWORD`
+
+Used by: `redis`
+
+Source: `src/redis/index.ts`
+
+Default: `null`
+
+The Redis helper passes `REDIS_PASSWORD` to `ioredis` as the client password. If unset, the helper passes `null`.
+
+Operational notes:
+
+- Set this variable when the Redis endpoint requires authentication.
+- Treat it as a secret.
+- `redis.getConnectionInfo()` returns the password, so downstream code should avoid logging that return value directly.
+
+### `QUEUED_CONNECTION_ATTEMPTS`
+
+Used by: `redis`
+
+Source: `src/redis/index.ts`
+
+Default: `3`
+
+The Redis helper passes `QUEUED_CONNECTION_ATTEMPTS` to `ioredis` as `maxRetriesPerRequest`. If unset, the default is `3`.
+
+Behavior:
+
+- Offline queueing is enabled when the client is created.
+- The helper re-enables offline queueing on `connect`.
+- On reconnecting, when `maxRetriesPerRequest` is present, the helper logs an error and disables the offline queue.
+
+Operational notes:
+
+- Use this variable to tune queued Redis command retry behavior.
+- Lower values reduce stale queued commands but can increase failed requests during transient Redis outages.
+- Higher values may preserve commands longer but can increase queue buildup during outages.
+
+## Documentation-only references
+
+### `NODE_ENV`
+
+Used by: logger README example only
+
+Source: `src/logger/README.md`
+
+`NODE_ENV` appears in an example wrapper that silences logging during tests:
+
+```js
+const isTests = process.env.NODE_ENV === 'test';
+```
+
+The runtime helpers do not read `NODE_ENV` directly.
+
+## Test-only environment behavior
+
+Tests mutate environment variables to simulate local and VIP runtime behavior.
+
+Common test patterns:
+
+- Save a copy of `process.env` before mutation.
+- Restore `process.env` after each test.
+- Set `VIP_GO_APP_ID` to mimic VIP Go mode.
+- Set New Relic variables to exercise skip/error/success paths.
+- Set Redis variables to exercise valid and invalid parsing paths.
+
+## Quick reference
+
+| Variable                     | Helper               | Required for runtime?              | Default or fallback                                     |
+| ---------------------------- | -------------------- | ---------------------------------- | ------------------------------------------------------- |
+| `PORT`                       | `server`             | no                                 | `3000`                                                  |
+| `NODEJS_APP_PROCESS`         | `logger`             | no                                 | `master`                                                |
+| `VIP_GO_SILENCE_LOGS`        | `logger`             | no                                 | logging enabled                                         |
+| `VIP_GO_APP_ID`              | `logger`, `newrelic` | required for VIP mode behavior     | local mode when absent                                  |
+| `NEW_RELIC_NO_CONFIG_FILE`   | `newrelic`           | yes, outside local mode            | skip New Relic when missing or not `true`               |
+| `NEW_RELIC_LICENSE_KEY`      | `newrelic`           | yes, outside local mode            | skip New Relic when missing                             |
+| `REDIS_MASTER`               | `redis`              | yes, for `redis()` client creation | log error and return `undefined` when missing/malformed |
+| `REDIS_PASSWORD`             | `redis`              | only when Redis requires auth      | `null`                                                  |
+| `QUEUED_CONNECTION_ATTEMPTS` | `redis`              | no                                 | `3`                                                     |
+| `NODE_ENV`                   | README example only  | no                                 | not read by runtime helpers                             |
+
+## Related docs
+
+- [Architecture](ARCHITECTURE.md)
+- [Testing](TESTING.md)
+- [Redis README](../src/redis/README.md)
+- [Logger README](../src/logger/README.md)
+- [New Relic README](../src/newrelic/README.md)
+- [Server README](../src/server/README.md)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,272 @@
+# Testing
+
+## Purpose
+
+This document describes how to validate `@automattic/vip-go`, what each test file covers, and the testing patterns maintainers should preserve when changing runtime helpers.
+
+## Test stack
+
+The package uses:
+
+- Node.js built-in test runner from `node:test`
+- Node.js strict assertions from `node:assert/strict`
+- `ts-node/register` to execute TypeScript tests without a separate test build
+- `node:module` hooks to mock `newrelic`
+- `node:test` module mocking to mock `ioredis`
+- Express for server helper integration tests
+- Custom `TestTransport` for logger/New Relic/Redis log assertions
+
+The primary test command is:
+
+```sh
+npm test
+```
+
+`npm test` runs:
+
+```sh
+npm run lint && npm run typecheck && npm run cmd:test
+```
+
+The direct test runner command is:
+
+```sh
+npm run cmd:test
+```
+
+It expands to:
+
+```sh
+node --no-warnings --require ts-node/register --experimental-test-module-mocks --test __tests__/*.spec.ts
+```
+
+## Validation commands
+
+Run these before opening or merging a change:
+
+```sh
+npm run lint
+npm run format:check
+npm run typecheck
+npm run cmd:test
+npm test
+npm run build
+```
+
+Command roles:
+
+- `npm run lint`: runs ESLint over JavaScript, JSX, TypeScript, and TSX files.
+- `npm run format:check`: verifies Prettier formatting.
+- `npm run typecheck`: runs `tsc --noEmit` for strict type validation.
+- `npm run cmd:test`: runs TypeScript specs through Node's test runner.
+- `npm test`: runs lint, typecheck, and tests together.
+- `npm run build`: emits CommonJS JavaScript and declarations into `dist/`.
+
+## Test file map
+
+### `__tests__/server.spec.ts`
+
+Covers `src/server`.
+
+Primary behavior under test:
+
+- Express-compatible apps can be wrapped.
+- Custom request handlers can be wrapped.
+- `/cache-healthcheck?` always returns `200` and `ok`.
+- Healthcheck requests are not forwarded to the custom request handler.
+- Existing routes continue to work.
+- Missing request handler throws `Please include a requestHandler`.
+- Explicit `PORT` option starts a listening server.
+- Wrapped server can be closed after integration tests.
+
+Important patterns:
+
+- Uses ephemeral ports when testing wrapped `app` directly.
+- Uses port `8000` only for explicit `PORT` behavior tests.
+- Closes started servers in `finally` blocks.
+
+### `__tests__/logger.spec.ts`
+
+Covers `src/logger`.
+
+Primary behavior under test:
+
+- Simple log messages are passed to the configured transport.
+- Winston string interpolation works.
+- Local logging format is used when `VIP_GO_APP_ID` is absent.
+- Production logging format is used when `VIP_GO_APP_ID` is present.
+- Custom labels are preserved in log output.
+- Required labels are added: `app`, `app_type`, `message_type`, `app_process`, and `app_worker`.
+- Cluster worker metadata is included when a custom cluster-like object is passed.
+- Per-logger `silent: true` suppresses logs.
+
+Important patterns:
+
+- Uses `TestTransport` instead of asserting console output.
+- Saves and restores `VIP_GO_APP_ID` around production-format tests.
+- Reads Winston's rendered message through `Symbol.for( 'message' )`.
+
+### `__tests__/newrelic.spec.ts`
+
+Covers `src/newrelic`.
+
+Primary behavior under test:
+
+- Local mode skips New Relic when `VIP_GO_APP_ID` is absent or empty.
+- Missing `NEW_RELIC_NO_CONFIG_FILE` logs an error and skips initialization.
+- `NEW_RELIC_NO_CONFIG_FILE=false` logs an error and skips initialization.
+- Missing `NEW_RELIC_LICENSE_KEY` logs an error and skips initialization.
+- Valid New Relic environment returns the loaded `newrelic` module.
+- Valid environment with missing `newrelic` package throws an import error.
+
+Important patterns:
+
+- Uses `registerHooks` from `node:module` to mock the `newrelic` import.
+- Restores module hooks after each test.
+- Restores `process.env` after each test and sets `VIP_GO_APP_ID` to mimic VIP Go mode.
+
+### `__tests__/redis.spec.ts`
+
+Covers `src/redis`.
+
+Primary behavior under test:
+
+- `redis.getConnectionInfo` is exposed.
+- Invalid `REDIS_MASTER` values return null connection info.
+- Valid `REDIS_MASTER` values return parsed host and port.
+- `REDIS_PASSWORD` is returned when present.
+- Missing or malformed `REDIS_MASTER` logs an error and avoids client creation.
+- Valid Redis environment initializes `ioredis` with expected options.
+- Client options include `enableOfflineQueue: true`, parsed host/port/password, default `maxRetriesPerRequest: 3`, and a retry strategy.
+
+Important patterns:
+
+- Uses `mock.module( 'ioredis', ... )` to avoid network connections.
+- Restores module mocks and `process.env` after tests.
+- Tests both positive and negative parsing examples for `REDIS_MASTER`.
+
+### `__tests__/testtransport.ts`
+
+Shared test helper.
+
+`TestTransport` extends `winston-transport` and records log payloads in memory:
+
+- `logs`: regular log/debug/info payloads
+- `errors`: error payloads
+
+Use it when testing helper behavior that writes to the logger interface.
+
+## Environment handling in tests
+
+Tests that mutate `process.env` should:
+
+1. Save the old environment before mutation.
+2. Restore it in `afterEach`.
+3. Set only the variables needed by the behavior under test.
+4. Use dummy secret values such as `ABC` or `secret123`, never real secrets.
+
+Example pattern:
+
+```ts
+const OLD_ENV_VARS = { ...process.env };
+
+afterEach( () => {
+	process.env = { ...OLD_ENV_VARS };
+} );
+```
+
+Some tests also set `VIP_GO_APP_ID` after restoration to keep later tests in VIP-like mode.
+
+## Mocking patterns
+
+### Mock dynamic CommonJS imports
+
+`newrelic` uses `require( 'newrelic' )`. Tests mock that import with `registerHooks` from `node:module`.
+
+Use this pattern when the dependency may not be installed or should not execute real agent behavior.
+
+### Mock `ioredis`
+
+Redis tests use `mock.module( 'ioredis', ... )` from `node:test` to replace the constructor. This avoids real Redis connections and lets tests assert constructor options.
+
+The test runner command includes `--experimental-test-module-mocks`; keep that flag while Redis tests depend on `mock.module`.
+
+## Adding tests for new behavior
+
+When adding or changing a helper:
+
+1. Add tests in the matching `__tests__/*.spec.ts` file.
+2. Use source-level imports from `../src/...`, not built `dist/` output.
+3. Prefer explicit behavior assertions over snapshots.
+4. Mock optional dependencies instead of adding service dependencies to the test environment.
+5. Restore global state such as `process.env`, module hooks, and mocks.
+6. Add type coverage through `npm run typecheck` when public types change.
+7. Run `npm run build` when package exports or declaration output changes.
+
+## Change-specific checklist
+
+### Server changes
+
+- Verify healthcheck behavior still returns `200` and `ok`.
+- Verify healthcheck is not forwarded to custom handlers.
+- Verify explicit `PORT` and default port behavior.
+- Verify `close()` is safe after `listen()`.
+
+### Logger changes
+
+- Verify local and production formats.
+- Verify label output remains stable for downstream log search.
+- Verify custom labels and message formatting still work.
+- Verify `silent` behavior and `VIP_GO_SILENCE_LOGS` behavior if touched.
+
+### New Relic changes
+
+- Verify local mode skip behavior.
+- Verify missing env vars log errors and skip initialization.
+- Verify valid config imports `newrelic`.
+- Verify missing package throws only after config is valid.
+
+### Redis changes
+
+- Verify valid and invalid `REDIS_MASTER` parsing.
+- Verify password handling.
+- Verify constructor options passed to `ioredis`.
+- Verify reconnect/offline queue behavior when changed.
+
+### Package/export changes
+
+- Run `npm run typecheck`.
+- Run `npm run build`.
+- Inspect `dist/src/index.d.ts` and exported type declarations.
+- Smoke-test package root and `@automattic/vip-go/types` imports.
+
+## Troubleshooting
+
+### Tests hang or port is already in use
+
+Check server tests that call `.listen()` with an explicit port. Ensure the server is closed in a `finally` block.
+
+### New Relic tests fail unexpectedly
+
+Check whether module hooks were deregistered or whether `process.env` was restored too early.
+
+### Redis tests try to connect to a real server
+
+Check whether `mock.module( 'ioredis', ... )` is active and whether the test command includes `--experimental-test-module-mocks`.
+
+### Typecheck passes but build output is stale
+
+Run:
+
+```sh
+npm run clean
+npm run build
+```
+
+Then inspect `dist/` output before publishing.
+
+## Related docs
+
+- [Architecture](ARCHITECTURE.md)
+- [Environment](ENVIRONMENT.md)
+- [Root README](../README.md)


### PR DESCRIPTION
## Current documentation targets

- `docs/ARCHITECTURE.md`
  - Purpose: explain the package role, public entry point, module responsibilities, runtime mode model, dependencies, compatibility notes, and change-risk map.

- `docs/ENVIRONMENT.md`
  - Purpose: list every runtime environment variable used by `@automattic/vip-go`, explain behavior and defaults, and separate runtime variables from documentation/test-only references.

- `docs/TESTING.md`
  - Purpose: document validation commands, test stack, per-spec coverage, mocking patterns, environment handling, and change-specific test checklists.

## Why this matters

- `@automattic/vip-go` is a shared helper package used directly and indirectly by other VIP Node projects.
- Module-level READMEs explain usage, but maintainers also need project-level docs for architecture, environment contracts, and testing strategy.
- The ongoing TypeScript migration raises the cost of implicit package contracts; documentation should make public behavior and validation expectations explicit.
- RAG workflows benefit from stable headings such as `Runtime variables`, `Module map`, `Validation commands`, and `Change-risk map`.

## Scope

In scope:

- Create `docs/ARCHITECTURE.md`, `docs/ENVIRONMENT.md`, and `docs/TESTING.md`.
- Ground each document in current source files, package scripts, module READMEs, and test coverage.
- Keep docs focused on maintainer and downstream-consumer questions.
- Cross-link the docs to each other.
- Optionally link the docs from the root `README.md` for discoverability.

Out of scope:

- Rewriting all module-level READMEs.
- Writing release notes for a specific package version.
- Documenting downstream applications in detail.
- Creating broad platform documentation outside `vip-go-node`.

---

The documented state is how the project will look after #384 gets merged.
