### PR TITLE
fix(logger): remove timestamp from production log format

### DIFF
--- a/__tests__/logger.spec.ts
+++ b/__tests__/logger.spec.ts
@@ -74,7 +74,7 @@ void describe( 'src/logger', async () => {
 				assert( typeof message === 'string', 'Expected log message to be a string' );
 				match(
 					message,
-					/^\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} GMT go:app {"message":"my message","level":"info","app":"go","app_type":"app","message_type":"info","app_process":"master","app_worker":"master"}$/
+					/^go:app {"message":"my message","level":"info","app":"go","app_type":"app","message_type":"info","app_process":"master","app_worker":"master"}$/
 				);
 			} );
 		} );

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,9 +1,8 @@
 import nodeCluster from 'node:cluster';
-import { createLogger, format, transports } from 'winston';
+import { createLogger, format, transports, type Logger } from 'winston';
 
 import type { ClusterLike, LoggerOptions } from './types';
 import type { TransformableInfo } from 'logform';
-import type { Logger } from 'winston';
 
 const { combine, timestamp, printf, splat } = format;
 
@@ -69,14 +68,12 @@ const localLoggingFormat = printf( output => {
 // Logging format for production
 const prodLoggingFormat = printf( output => {
 	const logOutput = output as LogEntry;
-	const { timestamp: time, app, app_type: type } = logOutput;
+	const { app, app_type: type } = logOutput;
 
 	// Can't include the timestamp in the JSON
 	delete logOutput.timestamp;
 
-	return `${ String( time ) } ${ String( app ) }:${ String( type ) } ${ JSON.stringify(
-		logOutput
-	) }`;
+	return `${ String( app ) }:${ String( type ) } ${ JSON.stringify( logOutput ) }`;
 } );
 
 function createGoLogger(


### PR DESCRIPTION
## Description

This pull request updates the logging format in the `src/logger` module to remove timestamps from production log output. Production log lines will now omit the timestamp, resulting in a simpler and more consistent log structure.

**Logging format changes:**

* The production log format in `src/logger/index.ts` no longer includes the timestamp in the output string; only the `app`, `app_type`, and the JSON-encoded log object are included.
* The corresponding test in `__tests__/logger.spec.ts` is updated to match the new log output format without the timestamp.

## Why

Production logs already have a timestamp. By removing the timestamp from the message itself, we make it easier to filter out uninteresting duplicate log lines.

## Steps to Test

Unit tests have been updated.